### PR TITLE
feat: add store prices and product management

### DIFF
--- a/e2e/item-prices.spec.ts
+++ b/e2e/item-prices.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * Item prices E2E tests — tests adding, editing, and deleting
+ * prices for items at different stores.
+ *
+ * Prerequisites are created at the start and cleaned up at the end:
+ * - Two stores ("Lidl" and "Continente")
+ * - A shopping list with an item ("Milk")
+ *
+ * The tests run SERIALLY because they form a natural sequence:
+ *   1. Create prerequisites (stores + list + item)
+ *   2. See "No prices yet" on the item
+ *   3. Add prices at different stores
+ *   4. Verify cheapest price display
+ *   5. Edit a price
+ *   6. Delete a price
+ *   7. Clean up
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe.serial("Item prices CRUD", () => {
+  const timestamp = Date.now();
+  const store1 = `Lidl ${timestamp}`;
+  const store2 = `Continente ${timestamp}`;
+  const listName = `Prices Test ${timestamp}`;
+
+  test("creates stores for testing prices", async ({ page }) => {
+    await page.goto("/stores");
+
+    // Create first store
+    await page.getByPlaceholder("Store name...").fill(store1);
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    await expect(page.getByText(store1)).toBeVisible();
+
+    // Create second store
+    await page.getByPlaceholder("Store name...").fill(store2);
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    await expect(page.getByText(store2)).toBeVisible();
+  });
+
+  test("creates a list and item for testing prices", async ({ page }) => {
+    await page.goto("/");
+
+    // Create a list
+    await page.getByPlaceholder("New list name...").fill(listName);
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    await expect(page.getByText(listName)).toBeVisible();
+
+    // Navigate to the list and add an item
+    await page.getByRole("link", { name: listName }).click();
+    await page.getByPlaceholder("Item name...").fill("Milk");
+    await page.getByRole("button", { name: "Add item" }).click();
+    await expect(page.getByText("Milk")).toBeVisible();
+  });
+
+  test("shows 'No prices yet' on a new item", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: listName }).click();
+
+    await expect(page.getByText("No prices yet")).toBeVisible();
+  });
+
+  test("adds a price at the first store", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: listName }).click();
+
+    // Expand the prices section
+    await page.getByText("No prices yet").click();
+
+    // Select store and enter price
+    await page.locator('select[name="store_id"]').selectOption({ label: store1 });
+    await page.locator('input[name="price"]').fill("0.89");
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+
+    // The price should appear and the summary should update
+    await expect(page.getByText(`Best: €0.89 at ${store1}`)).toBeVisible();
+  });
+
+  test("adds a price at the second store", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: listName }).click();
+
+    // Expand the prices section
+    await page.getByText(`Best: €0.89 at ${store1}`).click();
+
+    // Select second store and enter a higher price
+    await page.locator('select[name="store_id"]').selectOption({ label: store2 });
+    await page.locator('input[name="price"]').fill("1.05");
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+
+    // The summary should still show the cheaper store
+    await expect(page.getByText(`Best: €0.89 at ${store1}`)).toBeVisible();
+
+    // Both prices should exist — we verify by checking for their edit buttons
+    await expect(
+      page.getByRole("button", { name: `Edit price at ${store1}` })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: `Edit price at ${store2}` })
+    ).toBeVisible();
+  });
+
+  test("edits a price", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: listName }).click();
+
+    // Expand the prices section
+    await page.getByText(`Best: €0.89 at ${store1}`).click();
+
+    // Click edit on the first store's price
+    await page
+      .getByRole("button", { name: `Edit price at ${store1}` })
+      .click();
+
+    // Change the price to be more expensive than store2
+    const priceInput = page.locator('input[name="price"]').first();
+    await priceInput.clear();
+    await priceInput.fill("1.25");
+
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.request().method() === "POST" && resp.ok()
+      ),
+      page.getByRole("button", { name: "Save" }).click(),
+    ]);
+
+    // Reload to confirm the change persisted
+    await page.reload();
+
+    // Now the cheapest should be Continente
+    await expect(page.getByText(`Best: €1.05 at ${store2}`)).toBeVisible();
+  });
+
+  test("deletes a price", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: listName }).click();
+
+    // Expand the prices section
+    await page.getByText(`Best: €1.05 at ${store2}`).click();
+
+    // Handle the confirm dialog
+    page.on("dialog", (dialog) => dialog.accept());
+
+    // Delete the Continente price — find the edit button for that specific
+    // price, go up to its parent container, and click the Delete button
+    // next to it. This avoids accidentally hitting the item's Delete button.
+    const editPriceButton = page.getByRole("button", {
+      name: `Edit price at ${store2}`,
+    });
+    const priceActionRow = editPriceButton.locator("..");
+
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.request().method() === "POST" && resp.ok()
+      ),
+      priceActionRow.getByRole("button", { name: "Delete" }).click(),
+    ]);
+
+    // Reload to confirm the deletion persisted
+    await page.reload();
+
+    // After deletion, the summary should show the remaining store
+    await expect(page.getByText(`Best: €1.25 at ${store1}`)).toBeVisible();
+  });
+
+  test("cleans up test data", async ({ page }) => {
+    // Delete the test list (cascades to items and prices)
+    await page.goto("/");
+    page.on("dialog", (dialog) => dialog.accept());
+
+    const listCard = page
+      .locator('[class*="border-zinc-200"]')
+      .filter({ hasText: listName });
+    await listCard.getByRole("button", { name: "Delete" }).click();
+    await expect(page.getByText(listName)).not.toBeVisible();
+
+    // Delete the test stores
+    await page.goto("/stores");
+
+    // Delete first store
+    const store1Card = page
+      .locator('[class*="border-zinc-200"]')
+      .filter({ hasText: store1 });
+    if (await store1Card.isVisible().catch(() => false)) {
+      await store1Card.getByRole("button", { name: "Delete" }).click();
+    }
+
+    // Delete second store
+    const store2Card = page
+      .locator('[class*="border-zinc-200"]')
+      .filter({ hasText: store2 });
+    if (await store2Card.isVisible().catch(() => false)) {
+      await store2Card.getByRole("button", { name: "Delete" }).click();
+    }
+  });
+});

--- a/e2e/products.spec.ts
+++ b/e2e/products.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Products management E2E tests — tests viewing, renaming, merging,
+ * and deleting products.
+ *
+ * Products are created automatically when adding items to lists,
+ * so the setup creates a list with items to generate test products.
+ *
+ * The tests run SERIALLY:
+ *   1. Create prerequisite items (generates products)
+ *   2. Navigate to products page and verify products exist
+ *   3. Rename a product
+ *   4. Merge two products
+ *   5. Delete a product
+ *   6. Clean up
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe.serial("Products management", () => {
+  const timestamp = Date.now();
+  const listName = `Products Test ${timestamp}`;
+  // Two items with similar names to test merge
+  const item1 = `Caju ${timestamp}`;
+  const item2 = `Castanha ${timestamp}`;
+  const item3 = `Tofu ${timestamp}`;
+  const renamedItem = `Castanha de Caju ${timestamp}`;
+
+  test("creates a list with items to generate products", async ({ page }) => {
+    await page.goto("/");
+
+    // Create a test list
+    await page.getByPlaceholder("New list name...").fill(listName);
+    await page.getByRole("button", { name: "Add" }).click();
+    await expect(page.getByText(listName)).toBeVisible();
+
+    // Navigate to the list and add items
+    await page.getByRole("link", { name: listName }).click();
+
+    // Add first item
+    await page.getByPlaceholder("Item name...").fill(item1);
+    await page.getByRole("button", { name: "Add item" }).click();
+    await expect(page.getByText(item1)).toBeVisible();
+
+    // Add second item
+    await page.getByPlaceholder("Item name...").fill(item2);
+    await page.getByRole("button", { name: "Add item" }).click();
+    await expect(page.getByText(item2)).toBeVisible();
+
+    // Add third item
+    await page.getByPlaceholder("Item name...").fill(item3);
+    await page.getByRole("button", { name: "Add item" }).click();
+    await expect(page.getByText(item3)).toBeVisible();
+  });
+
+  test("shows products on the products page", async ({ page }) => {
+    await page.goto("/products");
+
+    await expect(page.getByText(item1)).toBeVisible();
+    await expect(page.getByText(item2)).toBeVisible();
+    await expect(page.getByText(item3)).toBeVisible();
+  });
+
+  test("renames a product", async ({ page }) => {
+    await page.goto("/products");
+
+    // Click Edit on item1 (Caju)
+    await page.getByRole("button", { name: `Edit ${item1}` }).click();
+
+    const editForm = page.locator("form").filter({ hasText: "Save" });
+    const editInput = editForm.getByRole("textbox");
+    await editInput.clear();
+    await editInput.fill(renamedItem);
+
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.request().method() === "POST" && resp.ok()
+      ),
+      editForm.getByRole("button", { name: "Save" }).click(),
+    ]);
+
+    await page.goto("/products");
+
+    // The renamed product should appear
+    await expect(page.getByText(renamedItem)).toBeVisible();
+    // The old name should be gone (exact match to avoid matching substring)
+    await expect(page.getByText(item1, { exact: true })).not.toBeVisible();
+  });
+
+  test("merges two products", async ({ page }) => {
+    await page.goto("/products");
+
+    // Merge item2 (Castanha) into renamedItem (Castanha de Caju)
+    const productCard = page
+      .locator('[class*="border-zinc-200"]')
+      .filter({ hasText: item2 });
+    await productCard.getByRole("button", { name: "Merge" }).click();
+
+    // Select the target product from the dropdown
+    await page.locator('select[name="target_id"]').selectOption({
+      label: renamedItem,
+    });
+
+    // Click the Merge button inside the merge form (the one with the dropdown)
+    const mergeForm = page.locator("form").filter({
+      has: page.locator('select[name="target_id"]'),
+    });
+
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.request().method() === "POST" && resp.ok()
+      ),
+      mergeForm.getByRole("button", { name: "Merge" }).click(),
+    ]);
+
+    await page.goto("/products");
+
+    // The source product (Castanha) should be gone
+    await expect(page.getByText(item2)).not.toBeVisible();
+    // The target product should still exist
+    await expect(page.getByText(renamedItem)).toBeVisible();
+  });
+
+  test("deletes a product", async ({ page }) => {
+    await page.goto("/products");
+
+    page.on("dialog", (dialog) => dialog.accept());
+
+    const productCard = page
+      .locator('[class*="border-zinc-200"]')
+      .filter({ hasText: item3 });
+    await productCard.getByRole("button", { name: "Delete" }).click();
+
+    await expect(page.getByText(item3)).not.toBeVisible();
+    // The other product should still be there
+    await expect(page.getByText(renamedItem)).toBeVisible();
+  });
+
+  test("cleans up test data", async ({ page }) => {
+    // Delete the test list
+    await page.goto("/");
+    page.on("dialog", (dialog) => dialog.accept());
+
+    const listCard = page
+      .locator('[class*="border-zinc-200"]')
+      .filter({ hasText: listName });
+    await listCard.getByRole("button", { name: "Delete" }).click();
+    await expect(page.getByText(listName)).not.toBeVisible();
+
+    // Delete remaining test products
+    await page.goto("/products");
+
+    const productCard = page
+      .locator('[class*="border-zinc-200"]')
+      .filter({ hasText: renamedItem });
+    if (await productCard.isVisible().catch(() => false)) {
+      await productCard.getByRole("button", { name: "Delete" }).click();
+    }
+  });
+});

--- a/e2e/stores.spec.ts
+++ b/e2e/stores.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Stores CRUD E2E tests — tests creating, reading, editing,
+ * and deleting stores.
+ *
+ * Same serial pattern as shopping-lists.spec.ts:
+ *   1. Start with a clean slate (delete leftover stores)
+ *   2. Create stores
+ *   3. Edit a store
+ *   4. Cancel an edit
+ *   5. Delete stores
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe.serial("Stores CRUD", () => {
+  const storeName1 = `Lidl ${Date.now()}`;
+  const storeName2 = `Continente ${Date.now()}`;
+  const editedName = `Lidl Portugal ${Date.now()}`;
+
+  test("shows empty state when no stores exist", async ({ page }) => {
+    await page.goto("/stores");
+
+    // Clean up any leftover stores from previous test runs
+    page.on("dialog", (dialog) => dialog.accept());
+
+    while (
+      await page
+        .getByRole("button", { name: "Delete" })
+        .first()
+        .isVisible()
+        .catch(() => false)
+    ) {
+      await page.getByRole("button", { name: "Delete" }).first().click();
+      await page.waitForTimeout(500);
+    }
+
+    await expect(page.getByText("No stores yet")).toBeVisible();
+    await expect(
+      page.getByText("Add your first store above to start tracking prices!")
+    ).toBeVisible();
+  });
+
+  test("creates a new store", async ({ page }) => {
+    await page.goto("/stores");
+
+    await page.getByPlaceholder("Store name...").fill(storeName1);
+    await page.getByRole("button", { name: "Add" }).click();
+
+    await expect(page.getByText(storeName1)).toBeVisible();
+    await expect(page.getByText("No stores yet")).not.toBeVisible();
+  });
+
+  test("creates a second store", async ({ page }) => {
+    await page.goto("/stores");
+
+    await page.getByPlaceholder("Store name...").fill(storeName2);
+    await page.getByRole("button", { name: "Add" }).click();
+
+    await expect(page.getByText(storeName1)).toBeVisible();
+    await expect(page.getByText(storeName2)).toBeVisible();
+  });
+
+  test("edits a store name", async ({ page }) => {
+    await page.goto("/stores");
+
+    await page
+      .getByRole("button", { name: `Edit ${storeName1}` })
+      .click();
+
+    const editForm = page.locator("form").filter({ hasText: "Save" });
+    const editInput = editForm.getByRole("textbox");
+    await editInput.clear();
+    await editInput.fill(editedName);
+
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.request().method() === "POST" && resp.ok()
+      ),
+      editForm.getByRole("button", { name: "Save" }).click(),
+    ]);
+
+    await page.goto("/stores");
+
+    await expect(page.getByText(editedName)).toBeVisible();
+    await expect(page.getByText(storeName1)).not.toBeVisible();
+  });
+
+  test("cancels editing without saving", async ({ page }) => {
+    await page.goto("/stores");
+
+    await page
+      .getByRole("button", { name: `Edit ${storeName2}` })
+      .click();
+
+    const editForm = page.locator("form").filter({ hasText: "Save" });
+    const editInput = editForm.getByRole("textbox");
+    await editInput.clear();
+    await editInput.fill("Should Not Save");
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    await expect(page.getByText(storeName2)).toBeVisible();
+    await expect(page.getByText("Should Not Save")).not.toBeVisible();
+  });
+
+  test("deletes a store", async ({ page }) => {
+    await page.goto("/stores");
+
+    page.on("dialog", (dialog) => dialog.accept());
+
+    const storeCard = page
+      .locator('[class*="border-zinc-200"]')
+      .filter({ hasText: editedName });
+    await storeCard.getByRole("button", { name: "Delete" }).click();
+
+    await expect(page.getByText(editedName)).not.toBeVisible();
+    await expect(page.getByText(storeName2)).toBeVisible();
+  });
+
+  test("deleting the last store shows empty state", async ({ page }) => {
+    await page.goto("/stores");
+
+    page.on("dialog", (dialog) => dialog.accept());
+
+    const storeCard = page
+      .locator('[class*="border-zinc-200"]')
+      .filter({ hasText: storeName2 });
+    await storeCard.getByRole("button", { name: "Delete" }).click();
+
+    await expect(page.getByText("No stores yet")).toBeVisible();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -78,7 +78,13 @@ export default defineConfig({
     // which invalidates the session on the Supabase server.
     {
       name: "authenticated",
-      testMatch: ["shopping-lists.spec.ts", "list-items.spec.ts"],
+      testMatch: [
+        "shopping-lists.spec.ts",
+        "list-items.spec.ts",
+        "stores.spec.ts",
+        "item-prices.spec.ts",
+        "products.spec.ts",
+      ],
       use: {
         ...devices["Desktop Chrome"],
         // Load the saved login session — tests skip the login page

--- a/src/app/(protected)/actions.ts
+++ b/src/app/(protected)/actions.ts
@@ -15,11 +15,49 @@
 
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 /** The shape returned by every action — either an error message or null */
 export type ActionResult = {
   error: string | null;
 };
+
+/**
+ * Find an existing product by name (case-insensitive) or create a new one.
+ *
+ * Products are shared across lists — if "Milk" already exists as a product,
+ * we reuse it so prices carry over. This is called when adding or updating
+ * a list item.
+ *
+ * Returns the product ID, or null if something went wrong.
+ */
+async function findOrCreateProduct(
+  supabase: SupabaseClient,
+  userId: string,
+  name: string
+): Promise<string | null> {
+  // Try to find an existing product with this name (case-insensitive)
+  const { data: existing } = await supabase
+    .from("products")
+    .select("id")
+    .eq("user_id", userId)
+    .ilike("name", name)
+    .limit(1)
+    .single();
+
+  if (existing) {
+    return existing.id;
+  }
+
+  // No match — create a new product
+  const { data: created } = await supabase
+    .from("products")
+    .insert({ name, user_id: userId })
+    .select("id")
+    .single();
+
+  return created?.id ?? null;
+}
 
 /**
  * Create a new shopping list.
@@ -143,6 +181,10 @@ export async function deleteList(
 
 /**
  * Add a new item to a shopping list.
+ *
+ * Also finds or creates a "product" for this item name. Products are
+ * shared across lists — if "Milk" already exists as a product (with
+ * prices), the new list item links to it automatically.
  */
 export async function addItem(
   previousState: ActionResult,
@@ -173,12 +215,38 @@ export async function addItem(
     return { error: "You must be logged in." };
   }
 
+  // Find or create a product with this name.
+  // ilike does a case-insensitive match so "Milk" and "milk" are the same product.
+  const productId = await findOrCreateProduct(supabase, user.id, name.trim());
+  if (!productId) {
+    return { error: "Could not create product. Please try again." };
+  }
+
+  // If the user didn't pick a category, try to auto-fill it from a previous
+  // usage of this product. For example, if "Amendoim" was previously added
+  // with "Nuts & Seeds", new list items for "Amendoim" get that category too.
+  let resolvedCategoryId = categoryId || null;
+  if (!resolvedCategoryId) {
+    const { data: previousItem } = await supabase
+      .from("list_items")
+      .select("category_id")
+      .eq("product_id", productId)
+      .not("category_id", "is", null)
+      .limit(1)
+      .single();
+
+    if (previousItem?.category_id) {
+      resolvedCategoryId = previousItem.category_id;
+    }
+  }
+
   const { error } = await supabase.from("list_items").insert({
     list_id: listId,
+    product_id: productId,
     name: name.trim(),
     quantity,
     unit: unit?.trim() || null, // empty string becomes null
-    category_id: categoryId || null, // empty string becomes null
+    category_id: resolvedCategoryId, // auto-filled from previous usage if not set
   });
 
   if (error) {
@@ -191,6 +259,10 @@ export async function addItem(
 
 /**
  * Update an existing list item (name, quantity, unit, category).
+ *
+ * If the name changes, the product link is updated to match the new name.
+ * For example, renaming "Milk" to "Organic Milk" links the item to the
+ * "Organic Milk" product (creating it if needed), so it shows different prices.
  */
 export async function updateItem(
   previousState: ActionResult,
@@ -221,11 +293,16 @@ export async function updateItem(
     return { error: "You must be logged in." };
   }
 
+  // Always find/create a product for the current name.
+  // If the user renamed the item, this links it to the correct product.
+  const productId = await findOrCreateProduct(supabase, user.id, name.trim());
+
   // RLS ensures users can only update items in their own lists
   const { error } = await supabase
     .from("list_items")
     .update({
       name: name.trim(),
+      product_id: productId,
       quantity,
       unit: unit?.trim() || null,
       category_id: categoryId || null,
@@ -315,6 +392,410 @@ export async function createCategory(
   }
 
   // Revalidate the list page so the new category appears in the dropdown
+  revalidatePath(`/lists/${listId}`);
+  return { error: null };
+}
+
+// ─── Product Actions ──────────────────────────────────────────────
+
+/**
+ * Rename a product.
+ *
+ * All list items linked to this product keep their link — they'll
+ * display the new name next time data is fetched.
+ */
+export async function updateProduct(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const id = formData.get("id") as string;
+  const name = formData.get("name") as string;
+
+  if (!name || name.trim().length === 0) {
+    return { error: "Product name cannot be empty." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  // Also update the name on all list items that use this product,
+  // so the display name stays in sync
+  const { error } = await supabase
+    .from("products")
+    .update({ name: name.trim() })
+    .eq("id", id);
+
+  if (error) {
+    return { error: "Could not rename product. Please try again." };
+  }
+
+  // Update list item names to match the new product name
+  await supabase
+    .from("list_items")
+    .update({ name: name.trim() })
+    .eq("product_id", id);
+
+  revalidatePath("/products");
+  return { error: null };
+}
+
+/**
+ * Delete a product and all its prices.
+ *
+ * List items that reference this product will have their product_id
+ * set to null (ON DELETE SET NULL), so they stay in their lists but
+ * lose their price data.
+ */
+export async function deleteProduct(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const id = formData.get("id") as string;
+
+  if (!id) {
+    return { error: "Missing product ID." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  const { error } = await supabase.from("products").delete().eq("id", id);
+
+  if (error) {
+    return { error: "Could not delete product. Please try again." };
+  }
+
+  revalidatePath("/products");
+  return { error: null };
+}
+
+/**
+ * Merge one product into another.
+ *
+ * All list items and prices from the source product are moved to the
+ * target product. If both products have a price at the same store,
+ * the target's price is kept. Then the source product is deleted.
+ *
+ * This is useful for cleaning up duplicates (e.g., merging "Caju"
+ * into "Castanha de Caju").
+ */
+export async function mergeProducts(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const sourceId = formData.get("source_id") as string;
+  const targetId = formData.get("target_id") as string;
+
+  if (!sourceId || !targetId) {
+    return { error: "Please select a product to merge into." };
+  }
+
+  if (sourceId === targetId) {
+    return { error: "Cannot merge a product into itself." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  // 1. Move list items from source to target
+  const { error: itemsError } = await supabase
+    .from("list_items")
+    .update({ product_id: targetId })
+    .eq("product_id", sourceId);
+
+  if (itemsError) {
+    return { error: "Could not merge list items. Please try again." };
+  }
+
+  // 2. Delete source prices that conflict with target prices
+  //    (same store). The target's prices take priority.
+  const { data: targetPrices } = await supabase
+    .from("item_prices")
+    .select("store_id")
+    .eq("product_id", targetId);
+
+  const targetStoreIds = (targetPrices ?? []).map((p) => p.store_id);
+
+  if (targetStoreIds.length > 0) {
+    await supabase
+      .from("item_prices")
+      .delete()
+      .eq("product_id", sourceId)
+      .in("store_id", targetStoreIds);
+  }
+
+  // 3. Move remaining source prices to target
+  await supabase
+    .from("item_prices")
+    .update({ product_id: targetId })
+    .eq("product_id", sourceId);
+
+  // 4. Delete the source product (now has no items or prices)
+  await supabase.from("products").delete().eq("id", sourceId);
+
+  revalidatePath("/products");
+  return { error: null };
+}
+
+// ─── Store Actions ────────────────────────────────────────────────
+
+/**
+ * Create a new store for the current user.
+ *
+ * Stores are user-level resources (not tied to a specific list).
+ * Each user has their own set of stores (e.g., "Lidl", "Continente").
+ */
+export async function createStore(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const name = formData.get("name") as string;
+
+  if (!name || name.trim().length === 0) {
+    return { error: "Please enter a store name." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  const { error } = await supabase
+    .from("stores")
+    .insert({ name: name.trim(), user_id: user.id });
+
+  if (error) {
+    return { error: "Could not create store. Please try again." };
+  }
+
+  revalidatePath("/stores");
+  return { error: null };
+}
+
+/**
+ * Rename an existing store.
+ */
+export async function updateStore(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const id = formData.get("id") as string;
+  const name = formData.get("name") as string;
+
+  if (!name || name.trim().length === 0) {
+    return { error: "Store name cannot be empty." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  // RLS ensures users can only update their own stores
+  const { error } = await supabase
+    .from("stores")
+    .update({ name: name.trim() })
+    .eq("id", id);
+
+  if (error) {
+    return { error: "Could not update store. Please try again." };
+  }
+
+  revalidatePath("/stores");
+  return { error: null };
+}
+
+/**
+ * Delete a store.
+ *
+ * This also deletes all item_prices at this store because the database
+ * schema uses ON DELETE CASCADE on the foreign key.
+ */
+export async function deleteStore(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const id = formData.get("id") as string;
+
+  if (!id) {
+    return { error: "Missing store ID." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  // RLS ensures users can only delete their own stores
+  const { error } = await supabase.from("stores").delete().eq("id", id);
+
+  if (error) {
+    return { error: "Could not delete store. Please try again." };
+  }
+
+  revalidatePath("/stores");
+  return { error: null };
+}
+
+// ─── Item Price Actions ───────────────────────────────────────────
+
+/**
+ * Add a price for a product at a specific store.
+ *
+ * Prices are on products (not list items), so they're shared across
+ * all lists that contain the same product. The unique constraint on
+ * (product_id, store_id) prevents duplicate prices.
+ */
+export async function addPrice(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const productId = formData.get("product_id") as string;
+  const storeId = formData.get("store_id") as string;
+  const priceRaw = formData.get("price") as string;
+  const listId = formData.get("list_id") as string;
+
+  if (!storeId) {
+    return { error: "Please select a store." };
+  }
+
+  if (!priceRaw || priceRaw.trim().length === 0) {
+    return { error: "Please enter a price." };
+  }
+
+  const price = parseFloat(priceRaw);
+  if (isNaN(price) || price < 0) {
+    return { error: "Price must be zero or a positive number." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  const { error } = await supabase
+    .from("item_prices")
+    .insert({ product_id: productId, store_id: storeId, price });
+
+  if (error) {
+    // The unique constraint will trigger an error if a price already exists
+    if (error.code === "23505") {
+      return { error: "This product already has a price at that store." };
+    }
+    return { error: "Could not add price. Please try again." };
+  }
+
+  revalidatePath(`/lists/${listId}`);
+  return { error: null };
+}
+
+/**
+ * Update the price of an existing item price entry.
+ */
+export async function updatePrice(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const id = formData.get("id") as string;
+  const priceRaw = formData.get("price") as string;
+  const listId = formData.get("list_id") as string;
+
+  if (!priceRaw || priceRaw.trim().length === 0) {
+    return { error: "Please enter a price." };
+  }
+
+  const price = parseFloat(priceRaw);
+  if (isNaN(price) || price < 0) {
+    return { error: "Price must be zero or a positive number." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  // RLS ensures users can only update prices for items in their own lists
+  const { error } = await supabase
+    .from("item_prices")
+    .update({ price })
+    .eq("id", id);
+
+  if (error) {
+    return { error: "Could not update price. Please try again." };
+  }
+
+  revalidatePath(`/lists/${listId}`);
+  return { error: null };
+}
+
+/**
+ * Delete an item price entry.
+ */
+export async function deletePrice(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const id = formData.get("id") as string;
+  const listId = formData.get("list_id") as string;
+
+  if (!id) {
+    return { error: "Missing price ID." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  // RLS ensures users can only delete prices for items in their own lists
+  const { error } = await supabase.from("item_prices").delete().eq("id", id);
+
+  if (error) {
+    return { error: "Could not delete price. Please try again." };
+  }
+
   revalidatePath(`/lists/${listId}`);
   return { error: null };
 }

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { LogoutButton } from "@/components/LogoutButton";
@@ -34,8 +35,32 @@ export default async function ProtectedLayout({
   return (
     <div className="min-h-screen bg-zinc-50">
       {/* Header bar shown on all protected pages */}
+      {/* Header bar shown on all protected pages */}
       <header className="flex items-center justify-between border-b bg-white px-4 py-3">
-        <h1 className="text-lg font-semibold">Best Basket</h1>
+        <div className="flex items-center gap-4">
+          <h1 className="text-lg font-semibold">Best Basket</h1>
+          {/* Navigation links for the main sections */}
+          <nav className="flex items-center gap-3">
+            <Link
+              href="/"
+              className="text-sm text-zinc-500 hover:text-zinc-700"
+            >
+              Lists
+            </Link>
+            <Link
+              href="/stores"
+              className="text-sm text-zinc-500 hover:text-zinc-700"
+            >
+              Stores
+            </Link>
+            <Link
+              href="/products"
+              className="text-sm text-zinc-500 hover:text-zinc-700"
+            >
+              Products
+            </Link>
+          </nav>
+        </div>
         <div className="flex items-center gap-3">
           <span className="text-sm text-zinc-500">{user.email}</span>
           <LogoutButton />

--- a/src/app/(protected)/lists/[id]/page.tsx
+++ b/src/app/(protected)/lists/[id]/page.tsx
@@ -3,18 +3,24 @@ import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { AddItemForm } from "@/components/AddItemForm";
 import { ListItemCard } from "@/components/ListItemCard";
+import { ItemPricesSection } from "@/components/ItemPricesSection";
 import { EmptyItemState } from "@/components/EmptyItemState";
 import {
   addItem,
   updateItem,
   deleteItem,
   createCategory,
+  addPrice,
+  updatePrice,
+  deletePrice,
 } from "@/app/(protected)/actions";
-import type { ListItemWithCategory } from "@/lib/types";
+import type { ListItemWithCategory, Store, ItemPriceWithStore } from "@/lib/types";
 
 /**
  * List detail page — shows a shopping list's items with the ability
  * to add, edit, delete, and categorize products.
+ *
+ * Also shows prices per item at different stores (Phase 4).
  *
  * This is a dynamic route — the [id] in the folder name means Next.js
  * will pass the list ID from the URL as params.id. For example,
@@ -63,6 +69,38 @@ export default async function ListDetailPage({
     .select("*")
     .or(`user_id.is.null,user_id.eq.${user?.id}`)
     .order("name");
+
+  // Fetch all stores for the current user (needed for the price dropdowns)
+  const { data: stores } = await supabase
+    .from("stores")
+    .select("*")
+    .order("name");
+
+  // Fetch prices by product_id. Prices are on products (not list items),
+  // so they're shared across lists. We collect the product_ids from the
+  // items, then fetch all prices for those products.
+  const productIds = (items ?? [])
+    .map((i) => i.product_id)
+    .filter((id): id is string => id !== null);
+  const uniqueProductIds = [...new Set(productIds)];
+
+  const { data: prices } =
+    uniqueProductIds.length > 0
+      ? await supabase
+          .from("item_prices")
+          .select("*, stores(name)")
+          .in("product_id", uniqueProductIds)
+      : { data: [] };
+
+  // Group prices by product_id so we can pass each item's prices easily.
+  // Multiple items can share the same product (and thus the same prices).
+  const pricesByProduct = new Map<string, ItemPriceWithStore[]>();
+  for (const price of (prices ?? []) as ItemPriceWithStore[]) {
+    if (!pricesByProduct.has(price.product_id)) {
+      pricesByProduct.set(price.product_id, []);
+    }
+    pricesByProduct.get(price.product_id)!.push(price);
+  }
 
   // Group items by category name so we can render them in sections.
   // Items without a category go into "Uncategorized".
@@ -117,13 +155,30 @@ export default async function ListDetailPage({
                 </p>
                 <div className="flex flex-col gap-2">
                   {groupItems.map((item) => (
-                    <ListItemCard
+                    <div
                       key={item.id}
-                      item={item}
-                      categories={categories ?? []}
-                      updateAction={updateItem}
-                      deleteAction={deleteItem}
-                    />
+                      className="rounded-md border border-zinc-200 bg-white"
+                    >
+                      {/* Item details (name, quantity, category, edit/delete) */}
+                      <ListItemCard
+                        item={item}
+                        categories={categories ?? []}
+                        updateAction={updateItem}
+                        deleteAction={deleteItem}
+                      />
+                      {/* Prices section — only shown if item has a product link */}
+                      {item.product_id && (
+                        <ItemPricesSection
+                          productId={item.product_id}
+                          listId={id}
+                          prices={pricesByProduct.get(item.product_id) ?? []}
+                          stores={(stores ?? []) as Store[]}
+                          addPriceAction={addPrice}
+                          updatePriceAction={updatePrice}
+                          deletePriceAction={deletePrice}
+                        />
+                      )}
+                    </div>
                   ))}
                 </div>
               </div>

--- a/src/app/(protected)/products/page.tsx
+++ b/src/app/(protected)/products/page.tsx
@@ -1,0 +1,107 @@
+import { createClient } from "@/lib/supabase/server";
+import {
+  updateProduct,
+  deleteProduct,
+  mergeProducts,
+} from "../actions";
+import { ProductCard } from "@/components/ProductCard";
+import type { ProductWithCounts } from "@/components/ProductCard";
+import { EmptyProductState } from "@/components/EmptyProductState";
+import type { ItemPriceWithStore } from "@/lib/types";
+
+/**
+ * Products page — shows all the user's products with usage counts.
+ *
+ * Products are created automatically when adding items to lists.
+ * This page lets users clean up their product catalog:
+ * - Rename products (fix typos)
+ * - Merge duplicates (e.g., "Caju" into "Castanha de Caju")
+ * - Delete unused products
+ */
+export default async function ProductsPage() {
+  const supabase = await createClient();
+
+  // Fetch all products for the current user.
+  // RLS ensures we only get the logged-in user's products.
+  const { data: products } = await supabase
+    .from("products")
+    .select("*")
+    .order("name");
+
+  // Fetch counts separately — how many list items and prices each product has.
+  // We do this with two simple queries rather than a complex join/RPC.
+  const productIds = (products ?? []).map((p) => p.id);
+
+  // Count list items per product
+  const { data: itemCounts } = productIds.length > 0
+    ? await supabase
+        .from("list_items")
+        .select("product_id")
+        .in("product_id", productIds)
+    : { data: [] };
+
+  // Fetch prices with store names (for display on each product card)
+  const { data: allPrices } = productIds.length > 0
+    ? await supabase
+        .from("item_prices")
+        .select("*, stores(name)")
+        .in("product_id", productIds)
+    : { data: [] };
+
+  // Build count maps
+  const itemCountMap = new Map<string, number>();
+  for (const row of itemCounts ?? []) {
+    itemCountMap.set(row.product_id, (itemCountMap.get(row.product_id) ?? 0) + 1);
+  }
+
+  const priceCountMap = new Map<string, number>();
+  for (const row of allPrices ?? []) {
+    priceCountMap.set(row.product_id, (priceCountMap.get(row.product_id) ?? 0) + 1);
+  }
+
+  // Group prices by product_id so we can pass them to each card
+  const pricesByProduct = new Map<string, ItemPriceWithStore[]>();
+  for (const price of (allPrices ?? []) as ItemPriceWithStore[]) {
+    if (!pricesByProduct.has(price.product_id)) {
+      pricesByProduct.set(price.product_id, []);
+    }
+    pricesByProduct.get(price.product_id)!.push(price);
+  }
+
+  // Combine products with their counts
+  const productsWithCounts: ProductWithCounts[] = (products ?? []).map((p) => ({
+    ...p,
+    item_count: itemCountMap.get(p.id) ?? 0,
+    price_count: priceCountMap.get(p.id) ?? 0,
+  }));
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2 className="text-xl font-semibold">My Products</h2>
+        <p className="mt-1 text-sm text-zinc-400">
+          Products are created automatically when you add items to lists.
+          Use this page to rename, merge duplicates, or delete unused products.
+        </p>
+      </div>
+
+      {productsWithCounts.length === 0 ? (
+        <EmptyProductState />
+      ) : (
+        <div className="flex flex-col gap-2">
+          {productsWithCounts.map((product) => (
+            <ProductCard
+              key={product.id}
+              product={product}
+              prices={pricesByProduct.get(product.id) ?? []}
+              allProducts={products ?? []}
+              updateAction={updateProduct}
+              deleteAction={deleteProduct}
+              mergeAction={mergeProducts}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(protected)/stores/page.tsx
+++ b/src/app/(protected)/stores/page.tsx
@@ -1,0 +1,56 @@
+import { createClient } from "@/lib/supabase/server";
+import { createStore, updateStore, deleteStore } from "../actions";
+import { StoreForm } from "@/components/StoreForm";
+import { StoreCard } from "@/components/StoreCard";
+import { EmptyStoreState } from "@/components/EmptyStoreState";
+import type { Store } from "@/lib/types";
+
+/**
+ * Stores page — shows the user's stores.
+ *
+ * Stores are user-level resources (not tied to a specific list).
+ * They represent shops where the user buys products (e.g., "Lidl",
+ * "Continente"). Prices on list items are linked to these stores.
+ *
+ * Same pattern as the home page (shopping lists):
+ * - Server Component that fetches data
+ * - StoreForm for creating
+ * - StoreCard for each store (with edit/delete)
+ */
+export default async function StoresPage() {
+  const supabase = await createClient();
+
+  // Fetch all stores for the current user, sorted alphabetically.
+  // RLS ensures we only get the logged-in user's stores.
+  const { data: stores } = await supabase
+    .from("stores")
+    .select("*")
+    .order("name");
+
+  const userStores = (stores ?? []) as Store[];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h2 className="text-xl font-semibold">My Stores</h2>
+
+      {/* Form to add a new store — always visible at the top */}
+      <StoreForm createAction={createStore} />
+
+      {/* Show the stores, or an empty state if there are none */}
+      {userStores.length === 0 ? (
+        <EmptyStoreState />
+      ) : (
+        <div className="flex flex-col gap-2">
+          {userStores.map((store) => (
+            <StoreCard
+              key={store.id}
+              store={store}
+              updateAction={updateStore}
+              deleteAction={deleteStore}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -5,16 +5,21 @@
  * ShoppingListForm on the home page). Fields: name, quantity, unit,
  * and category — only name is required.
  *
+ * The name field has autocomplete — as you type, it suggests matching
+ * products from your existing product catalog. Picking a suggestion
+ * reuses that product (so prices and category carry over automatically).
+ *
  * Uses useActionState + formRef to clear the form after a successful
  * submission (same pattern as ShoppingListForm).
  */
 "use client";
 
-import { useActionState, useRef, useState } from "react";
+import { useActionState, useRef, useState, useEffect } from "react";
 import { SubmitButton } from "@/components/SubmitButton";
 import { CreateCategoryForm } from "@/components/CreateCategoryForm";
+import { createClient } from "@/lib/supabase/client";
 import type { ActionResult } from "@/app/(protected)/actions";
-import type { Category } from "@/lib/types";
+import type { Category, Product } from "@/lib/types";
 
 export function AddItemForm({
   listId,
@@ -40,11 +45,43 @@ export function AddItemForm({
   const formRef = useRef<HTMLFormElement>(null);
   const [showNewCategory, setShowNewCategory] = useState(false);
 
+  // ─── Autocomplete state ───
+  const [nameValue, setNameValue] = useState("");
+  const [suggestions, setSuggestions] = useState<Product[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  // Debounced search: query products after the user stops typing for 300ms.
+  // useEffect runs whenever nameValue changes. The timeout is cleaned up
+  // if the user types again before 300ms, preventing too many requests.
+  useEffect(() => {
+    if (nameValue.trim().length < 2) {
+      setSuggestions([]);
+      return;
+    }
+
+    const timer = setTimeout(async () => {
+      const supabase = createClient();
+      const { data } = await supabase
+        .from("products")
+        .select("id, name, user_id")
+        .ilike("name", `%${nameValue.trim()}%`)
+        .order("name")
+        .limit(5);
+
+      setSuggestions((data ?? []) as Product[]);
+      setShowSuggestions(true);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [nameValue]);
+
   const [state, formAction] = useActionState(
     async (previousState: ActionResult, formData: FormData) => {
       const result = await addItemAction(previousState, formData);
       if (!result.error) {
         formRef.current?.reset();
+        setNameValue("");
+        setSuggestions([]);
       }
       return result;
     },
@@ -56,14 +93,49 @@ export function AddItemForm({
       <form ref={formRef} action={formAction} className="flex flex-col gap-3">
         <input type="hidden" name="list_id" value={listId} />
 
-        {/* Item name — the only required field */}
-        <input
-          type="text"
-          name="name"
-          placeholder="Item name..."
-          required
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none"
-        />
+        {/* Item name with autocomplete suggestions */}
+        <div className="relative">
+          <input
+            type="text"
+            name="name"
+            placeholder="Item name..."
+            required
+            value={nameValue}
+            onChange={(e) => setNameValue(e.target.value)}
+            onFocus={() => {
+              if (suggestions.length > 0) setShowSuggestions(true);
+            }}
+            onBlur={() => {
+              // Small delay so click on suggestion registers before hiding
+              setTimeout(() => setShowSuggestions(false), 150);
+            }}
+            autoComplete="off"
+            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none"
+          />
+
+          {/* Suggestions dropdown */}
+          {showSuggestions && suggestions.length > 0 && (
+            <ul className="absolute z-10 mt-1 w-full rounded-md border border-zinc-200 bg-white shadow-md">
+              {suggestions.map((product) => (
+                <li key={product.id}>
+                  <button
+                    type="button"
+                    onMouseDown={(e) => {
+                      // onMouseDown fires before onBlur, so the click registers
+                      e.preventDefault();
+                      setNameValue(product.name);
+                      setSuggestions([]);
+                      setShowSuggestions(false);
+                    }}
+                    className="w-full px-3 py-2 text-left text-sm text-zinc-700 hover:bg-zinc-50"
+                  >
+                    {product.name}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
 
         {/* Quantity, unit, and category on the same row */}
         <div className="flex gap-2">

--- a/src/components/AddPriceForm.test.tsx
+++ b/src/components/AddPriceForm.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from "@testing-library/react";
+import { AddPriceForm } from "./AddPriceForm";
+import type { Store, ItemPriceWithStore } from "@/lib/types";
+
+// Mock useActionState from React
+const mockFormAction = jest.fn();
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useActionState: (action: unknown, initialState: unknown) => [
+    initialState,
+    mockFormAction,
+  ],
+}));
+
+// Mock useFormStatus used inside SubmitButton
+jest.mock("react-dom", () => ({
+  ...jest.requireActual("react-dom"),
+  useFormStatus: () => ({ pending: false }),
+}));
+
+const mockStores: Store[] = [
+  { id: "store-1", user_id: "user-1", name: "Lidl" },
+  { id: "store-2", user_id: "user-1", name: "Continente" },
+];
+
+const mockAddPriceAction = jest.fn();
+
+describe("AddPriceForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders store dropdown, price input, and submit button", () => {
+    render(
+      <AddPriceForm
+        productId="product-1"
+        listId="list-1"
+        stores={mockStores}
+        existingPrices={[]}
+        addPriceAction={mockAddPriceAction}
+      />
+    );
+
+    // Store dropdown should have "Select store..." + 2 stores
+    const select = screen.getByRole("combobox");
+    const options = select.querySelectorAll("option");
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveTextContent("Select store...");
+    expect(options[1]).toHaveTextContent("Lidl");
+    expect(options[2]).toHaveTextContent("Continente");
+
+    // Price input
+    expect(screen.getByPlaceholderText("0.00")).toBeInTheDocument();
+
+    // Submit button
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+  });
+
+  it("shows link to stores page when user has no stores", () => {
+    render(
+      <AddPriceForm
+        productId="product-1"
+        listId="list-1"
+        stores={[]}
+        existingPrices={[]}
+        addPriceAction={mockAddPriceAction}
+      />
+    );
+
+    expect(screen.getByText("Add stores")).toBeInTheDocument();
+    expect(screen.getByText("Add stores")).toHaveAttribute("href", "/stores");
+  });
+
+  it("shows message when all stores already have prices", () => {
+    const existingPrices: ItemPriceWithStore[] = [
+      {
+        id: "price-1",
+        product_id: "product-1",
+        store_id: "store-1",
+        price: 0.89,
+        stores: { name: "Lidl" },
+      },
+      {
+        id: "price-2",
+        product_id: "product-1",
+        store_id: "store-2",
+        price: 1.05,
+        stores: { name: "Continente" },
+      },
+    ];
+
+    render(
+      <AddPriceForm
+        productId="product-1"
+        listId="list-1"
+        stores={mockStores}
+        existingPrices={existingPrices}
+        addPriceAction={mockAddPriceAction}
+      />
+    );
+
+    expect(
+      screen.getByText("All stores have prices for this item.")
+    ).toBeInTheDocument();
+  });
+
+  it("excludes stores that already have a price from the dropdown", () => {
+    const existingPrices: ItemPriceWithStore[] = [
+      {
+        id: "price-1",
+        product_id: "product-1",
+        store_id: "store-1",
+        price: 0.89,
+        stores: { name: "Lidl" },
+      },
+    ];
+
+    render(
+      <AddPriceForm
+        productId="product-1"
+        listId="list-1"
+        stores={mockStores}
+        existingPrices={existingPrices}
+        addPriceAction={mockAddPriceAction}
+      />
+    );
+
+    const select = screen.getByRole("combobox");
+    const options = select.querySelectorAll("option");
+    // Only "Select store..." + Continente (Lidl is excluded)
+    expect(options).toHaveLength(2);
+    expect(options[1]).toHaveTextContent("Continente");
+  });
+});

--- a/src/components/AddPriceForm.tsx
+++ b/src/components/AddPriceForm.tsx
@@ -1,0 +1,120 @@
+/**
+ * A form to add a price for a product at a specific store.
+ *
+ * Shows a store dropdown and price input. If the user has no stores,
+ * it shows a link to the /stores page instead.
+ *
+ * The store dropdown excludes stores that already have a price for this
+ * product — each product can only have one price per store.
+ */
+"use client";
+
+import { useActionState, useRef } from "react";
+import Link from "next/link";
+import { SubmitButton } from "@/components/SubmitButton";
+import type { ActionResult } from "@/app/(protected)/actions";
+import type { Store, ItemPriceWithStore } from "@/lib/types";
+
+export function AddPriceForm({
+  productId,
+  listId,
+  stores,
+  existingPrices,
+  addPriceAction,
+}: {
+  /** The product this price will be added to */
+  productId: string;
+  /** The list ID — needed for revalidation after adding */
+  listId: string;
+  /** All of the user's stores */
+  stores: Store[];
+  /** Prices already set for this item (used to filter out taken stores) */
+  existingPrices: ItemPriceWithStore[];
+  /** Server Action to add the price */
+  addPriceAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+}) {
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const [state, formAction] = useActionState(
+    async (previousState: ActionResult, formData: FormData) => {
+      const result = await addPriceAction(previousState, formData);
+      if (!result.error) {
+        formRef.current?.reset();
+      }
+      return result;
+    },
+    { error: null }
+  );
+
+  // Filter out stores that already have a price for this item
+  const storesWithPrice = new Set(existingPrices.map((p) => p.store_id));
+  const availableStores = stores.filter((s) => !storesWithPrice.has(s.id));
+
+  // If the user has no stores at all, point them to the stores page
+  if (stores.length === 0) {
+    return (
+      <p className="text-xs text-zinc-400">
+        <Link href="/stores" className="underline hover:text-zinc-600">
+          Add stores
+        </Link>{" "}
+        first to start tracking prices.
+      </p>
+    );
+  }
+
+  // If all stores already have prices for this item, show a message
+  if (availableStores.length === 0) {
+    return (
+      <p className="text-xs text-zinc-400">
+        All stores have prices for this item.
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <form ref={formRef} action={formAction} className="flex gap-2">
+        <input type="hidden" name="product_id" value={productId} />
+        <input type="hidden" name="list_id" value={listId} />
+
+        {/* Store dropdown — only shows stores without a price for this item */}
+        <select
+          name="store_id"
+          required
+          className="flex-1 rounded-md border border-zinc-300 px-2 py-1.5 text-xs text-zinc-700 focus:border-zinc-500 focus:outline-none"
+        >
+          <option value="">Select store...</option>
+          {availableStores.map((store) => (
+            <option key={store.id} value={store.id}>
+              {store.name}
+            </option>
+          ))}
+        </select>
+
+        {/* Price input — allows cents (step 0.01) */}
+        <input
+          type="number"
+          name="price"
+          placeholder="0.00"
+          min={0}
+          step="0.01"
+          required
+          className="w-24 rounded-md border border-zinc-300 px-2 py-1.5 text-xs focus:border-zinc-500 focus:outline-none"
+        />
+
+        <SubmitButton
+          label="Add"
+          pendingLabel="..."
+          className="rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+        />
+      </form>
+
+      {state.error && (
+        <p className="mt-1 text-xs text-red-600">{state.error}</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/EmptyProductState.test.tsx
+++ b/src/components/EmptyProductState.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { EmptyProductState } from "./EmptyProductState";
+
+describe("EmptyProductState", () => {
+  it("renders the empty state message", () => {
+    render(<EmptyProductState />);
+
+    expect(screen.getByText("No products yet")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Products are created automatically when you add items to your lists."
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/EmptyProductState.tsx
+++ b/src/components/EmptyProductState.tsx
@@ -1,0 +1,16 @@
+/**
+ * Shown when the user has no products yet.
+ *
+ * Products are created automatically when adding items to lists,
+ * so this state is rare — only shows for brand new users.
+ */
+export function EmptyProductState() {
+  return (
+    <div className="py-12 text-center">
+      <p className="text-lg font-medium text-zinc-400">No products yet</p>
+      <p className="mt-1 text-sm text-zinc-400">
+        Products are created automatically when you add items to your lists.
+      </p>
+    </div>
+  );
+}

--- a/src/components/EmptyStoreState.test.tsx
+++ b/src/components/EmptyStoreState.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { EmptyStoreState } from "./EmptyStoreState";
+
+describe("EmptyStoreState", () => {
+  it("renders the empty state message", () => {
+    render(<EmptyStoreState />);
+
+    expect(screen.getByText("No stores yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("Add your first store above to start tracking prices!")
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/EmptyStoreState.tsx
+++ b/src/components/EmptyStoreState.tsx
@@ -1,0 +1,15 @@
+/**
+ * Shown when the user has no stores yet.
+ *
+ * Same pattern as EmptyListState — a simple presentational component.
+ */
+export function EmptyStoreState() {
+  return (
+    <div className="py-12 text-center">
+      <p className="text-lg font-medium text-zinc-400">No stores yet</p>
+      <p className="mt-1 text-sm text-zinc-400">
+        Add your first store above to start tracking prices!
+      </p>
+    </div>
+  );
+}

--- a/src/components/ItemPriceRow.test.tsx
+++ b/src/components/ItemPriceRow.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ItemPriceRow } from "./ItemPriceRow";
+import type { ItemPriceWithStore } from "@/lib/types";
+
+// Mock useActionState — returns [state, formAction]
+// ItemPriceRow calls useActionState twice: first for update, then for delete
+const mockUpdateFormAction = jest.fn();
+const mockDeleteFormAction = jest.fn();
+let useActionStateCallCount = 0;
+
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useActionState: () => {
+    useActionStateCallCount++;
+    if (useActionStateCallCount % 2 === 1) {
+      return [{ error: null }, mockUpdateFormAction];
+    }
+    return [{ error: null }, mockDeleteFormAction];
+  },
+}));
+
+// Mock useFormStatus used inside SubmitButton
+jest.mock("react-dom", () => ({
+  ...jest.requireActual("react-dom"),
+  useFormStatus: () => ({ pending: false }),
+}));
+
+// Mock window.confirm
+const mockConfirm = jest.fn();
+window.confirm = mockConfirm;
+
+const mockPrice: ItemPriceWithStore = {
+  id: "price-1",
+  product_id: "product-1",
+  store_id: "store-1",
+  price: 0.89,
+  stores: { name: "Lidl" },
+};
+
+const mockUpdateAction = jest.fn();
+const mockDeleteAction = jest.fn();
+
+describe("ItemPriceRow", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useActionStateCallCount = 0;
+  });
+
+  it("renders store name and price in view mode", () => {
+    render(
+      <ItemPriceRow
+        price={mockPrice}
+        listId="list-1"
+        updatePriceAction={mockUpdateAction}
+        deletePriceAction={mockDeleteAction}
+      />
+    );
+
+    expect(screen.getByText("Lidl")).toBeInTheDocument();
+    expect(screen.getByText("€0.89")).toBeInTheDocument();
+  });
+
+  it("renders edit and delete buttons", () => {
+    render(
+      <ItemPriceRow
+        price={mockPrice}
+        listId="list-1"
+        updatePriceAction={mockUpdateAction}
+        deletePriceAction={mockDeleteAction}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Edit price at Lidl" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Delete" })
+    ).toBeInTheDocument();
+  });
+
+  it("switches to edit mode when edit button is clicked", () => {
+    render(
+      <ItemPriceRow
+        price={mockPrice}
+        listId="list-1"
+        updatePriceAction={mockUpdateAction}
+        deletePriceAction={mockDeleteAction}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit price at Lidl" })
+    );
+
+    // Should show price input with current value
+    expect(screen.getByDisplayValue("0.89")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Cancel" })
+    ).toBeInTheDocument();
+  });
+
+  it("exits edit mode when cancel is clicked", () => {
+    render(
+      <ItemPriceRow
+        price={mockPrice}
+        listId="list-1"
+        updatePriceAction={mockUpdateAction}
+        deletePriceAction={mockDeleteAction}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit price at Lidl" })
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    // Back in view mode
+    expect(screen.getByText("Lidl")).toBeInTheDocument();
+    expect(screen.getByText("€0.89")).toBeInTheDocument();
+  });
+
+  it("shows confirm dialog when delete is clicked", () => {
+    mockConfirm.mockReturnValue(false);
+
+    render(
+      <ItemPriceRow
+        price={mockPrice}
+        listId="list-1"
+        updatePriceAction={mockUpdateAction}
+        deletePriceAction={mockDeleteAction}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(mockConfirm).toHaveBeenCalledWith("Delete price at Lidl?");
+  });
+});

--- a/src/components/ItemPriceRow.tsx
+++ b/src/components/ItemPriceRow.tsx
@@ -1,0 +1,134 @@
+/**
+ * Displays a single price entry (store name + price) with edit/delete.
+ *
+ * Same dual-mode pattern as ShoppingListCard and ListItemCard:
+ * - View mode: shows "Lidl — €0.89" with edit/delete buttons
+ * - Edit mode: price input with save/cancel buttons
+ */
+"use client";
+
+import { useState, useActionState } from "react";
+import { SubmitButton } from "@/components/SubmitButton";
+import type { ItemPriceWithStore } from "@/lib/types";
+import type { ActionResult } from "@/app/(protected)/actions";
+
+export function ItemPriceRow({
+  price,
+  listId,
+  updatePriceAction,
+  deletePriceAction,
+}: {
+  /** The price entry to display (includes store name) */
+  price: ItemPriceWithStore;
+  /** The list ID — needed for revalidation */
+  listId: string;
+  /** Server Action to update the price */
+  updatePriceAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+  /** Server Action to delete the price */
+  deletePriceAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+
+  const [updateState, updateFormAction] = useActionState(
+    async (previousState: ActionResult, formData: FormData) => {
+      const result = await updatePriceAction(previousState, formData);
+      if (!result.error) {
+        setIsEditing(false);
+      }
+      return result;
+    },
+    { error: null }
+  );
+  const [deleteState, deleteFormAction] = useActionState(deletePriceAction, {
+    error: null,
+  });
+
+  const error = updateState.error || deleteState.error;
+
+  return (
+    <div className="flex flex-col">
+      {isEditing ? (
+        // ─── Edit Mode ───
+        <form action={updateFormAction} className="flex items-center gap-2">
+          <input type="hidden" name="id" value={price.id} />
+          <input type="hidden" name="list_id" value={listId} />
+          <span className="text-xs text-zinc-500">{price.stores.name}</span>
+          <input
+            type="number"
+            name="price"
+            defaultValue={price.price}
+            min={0}
+            step="0.01"
+            required
+            autoFocus
+            className="w-24 rounded-md border border-zinc-300 px-2 py-1 text-xs focus:border-zinc-500 focus:outline-none"
+          />
+          <SubmitButton
+            label="Save"
+            pendingLabel="..."
+            className="rounded-md bg-zinc-900 px-2 py-1 text-xs font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+          />
+          <button
+            type="button"
+            onClick={() => setIsEditing(false)}
+            className="rounded-md border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100"
+          >
+            Cancel
+          </button>
+        </form>
+      ) : (
+        // ─── View Mode ───
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-zinc-600">
+              {price.stores.name}
+            </span>
+            <span className="text-xs text-zinc-400">
+              &euro;{Number(price.price).toFixed(2)}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setIsEditing(true)}
+              className="rounded-md px-1.5 py-0.5 text-xs text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600"
+              aria-label={`Edit price at ${price.stores.name}`}
+            >
+              Edit
+            </button>
+
+            <form
+              className="flex"
+              action={deleteFormAction}
+              onSubmit={(e) => {
+                const confirmed = window.confirm(
+                  `Delete price at ${price.stores.name}?`
+                );
+                if (!confirmed) {
+                  e.preventDefault();
+                }
+              }}
+            >
+              <input type="hidden" name="id" value={price.id} />
+              <input type="hidden" name="list_id" value={listId} />
+              <button
+                type="submit"
+                className="rounded-md px-1.5 py-0.5 text-xs text-red-500 hover:bg-red-50"
+              >
+                Delete
+              </button>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/ItemPricesSection.test.tsx
+++ b/src/components/ItemPricesSection.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ItemPricesSection } from "./ItemPricesSection";
+import type { Store, ItemPriceWithStore } from "@/lib/types";
+
+// Mock useActionState — ItemPriceRow uses it twice (update + delete),
+// and AddPriceForm uses it once. We return the initial state for all.
+const mockFormAction = jest.fn();
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useActionState: (action: unknown, initialState: unknown) => [
+    initialState,
+    mockFormAction,
+  ],
+}));
+
+// Mock useFormStatus used inside SubmitButton
+jest.mock("react-dom", () => ({
+  ...jest.requireActual("react-dom"),
+  useFormStatus: () => ({ pending: false }),
+}));
+
+const mockStores: Store[] = [
+  { id: "store-1", user_id: "user-1", name: "Lidl" },
+  { id: "store-2", user_id: "user-1", name: "Continente" },
+];
+
+const mockPrices: ItemPriceWithStore[] = [
+  {
+    id: "price-1",
+    product_id: "product-1",
+    store_id: "store-1",
+    price: 0.89,
+    stores: { name: "Lidl" },
+  },
+  {
+    id: "price-2",
+    product_id: "product-1",
+    store_id: "store-2",
+    price: 1.05,
+    stores: { name: "Continente" },
+  },
+];
+
+const mockActions = {
+  addPriceAction: jest.fn(),
+  updatePriceAction: jest.fn(),
+  deletePriceAction: jest.fn(),
+};
+
+describe("ItemPricesSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows 'No prices yet' when there are no prices", () => {
+    render(
+      <ItemPricesSection
+        productId="product-1"
+        listId="list-1"
+        prices={[]}
+        stores={mockStores}
+        {...mockActions}
+      />
+    );
+
+    expect(screen.getByText("No prices yet")).toBeInTheDocument();
+  });
+
+  it("shows cheapest price summary when prices exist", () => {
+    render(
+      <ItemPricesSection
+        productId="product-1"
+        listId="list-1"
+        prices={mockPrices}
+        stores={mockStores}
+        {...mockActions}
+      />
+    );
+
+    expect(
+      screen.getByText("Best: €0.89 at Lidl")
+    ).toBeInTheDocument();
+  });
+
+  it("starts collapsed and expands when clicked", () => {
+    render(
+      <ItemPricesSection
+        productId="product-1"
+        listId="list-1"
+        prices={mockPrices}
+        stores={mockStores}
+        {...mockActions}
+      />
+    );
+
+    // Should not show individual prices yet (collapsed)
+    expect(screen.queryByText("€0.89")).not.toBeInTheDocument();
+
+    // Click to expand
+    fireEvent.click(screen.getByText("Best: €0.89 at Lidl"));
+
+    // Should now show individual price rows
+    expect(screen.getByText("€0.89")).toBeInTheDocument();
+    expect(screen.getByText("€1.05")).toBeInTheDocument();
+  });
+
+  it("collapses when clicked again", () => {
+    render(
+      <ItemPricesSection
+        productId="product-1"
+        listId="list-1"
+        prices={mockPrices}
+        stores={mockStores}
+        {...mockActions}
+      />
+    );
+
+    // Expand
+    fireEvent.click(screen.getByText("Best: €0.89 at Lidl"));
+    expect(screen.getByText("€0.89")).toBeInTheDocument();
+
+    // Collapse
+    fireEvent.click(screen.getByText("Best: €0.89 at Lidl"));
+    expect(screen.queryByText("€0.89")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ItemPricesSection.tsx
+++ b/src/components/ItemPricesSection.tsx
@@ -1,0 +1,114 @@
+/**
+ * Collapsible section showing prices for a product.
+ *
+ * When collapsed, shows a summary (cheapest price or "No prices yet").
+ * When expanded, shows all prices with edit/delete + a form to add more.
+ *
+ * Prices are on products (shared across lists), so if "Milk" costs €0.89
+ * at Lidl, every list with "Milk" shows the same price.
+ *
+ * This component is placed below each ListItemCard in the list detail page.
+ */
+"use client";
+
+import { useState } from "react";
+import { ItemPriceRow } from "@/components/ItemPriceRow";
+import { AddPriceForm } from "@/components/AddPriceForm";
+import type { Store, ItemPriceWithStore } from "@/lib/types";
+import type { ActionResult } from "@/app/(protected)/actions";
+
+export function ItemPricesSection({
+  productId,
+  listId,
+  prices,
+  stores,
+  addPriceAction,
+  updatePriceAction,
+  deletePriceAction,
+}: {
+  /** The product these prices belong to */
+  productId: string;
+  /** The list ID — needed for revalidation */
+  listId: string;
+  /** Existing prices for this product (with store names) */
+  prices: ItemPriceWithStore[];
+  /** All of the user's stores */
+  stores: Store[];
+  /** Server Action to add a price */
+  addPriceAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+  /** Server Action to update a price */
+  updatePriceAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+  /** Server Action to delete a price */
+  deletePriceAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // Find the cheapest price to show in the summary
+  const cheapest =
+    prices.length > 0
+      ? prices.reduce((min, p) =>
+          Number(p.price) < Number(min.price) ? p : min
+        )
+      : null;
+
+  // Sort prices by store name for consistent display
+  const sortedPrices = [...prices].sort((a, b) =>
+    a.stores.name.localeCompare(b.stores.name)
+  );
+
+  return (
+    <div className="border-t border-zinc-100 px-3 pb-2">
+      {/* Clickable summary row — toggles expand/collapse */}
+      <button
+        type="button"
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex w-full items-center justify-between py-1.5 text-left"
+      >
+        <span className="text-xs text-zinc-400">
+          {cheapest
+            ? `Best: €${Number(cheapest.price).toFixed(2)} at ${cheapest.stores.name}`
+            : "No prices yet"}
+        </span>
+        <span className="text-xs text-zinc-300">{isExpanded ? "▲" : "▼"}</span>
+      </button>
+
+      {/* Expanded content: list of prices + add form */}
+      {isExpanded && (
+        <div className="flex flex-col gap-2 pb-1">
+          {/* Existing prices */}
+          {sortedPrices.length > 0 && (
+            <div className="flex flex-col gap-1">
+              {sortedPrices.map((price) => (
+                <ItemPriceRow
+                  key={price.id}
+                  price={price}
+                  listId={listId}
+                  updatePriceAction={updatePriceAction}
+                  deletePriceAction={deletePriceAction}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Form to add a new price */}
+          <AddPriceForm
+            productId={productId}
+            listId={listId}
+            stores={stores}
+            existingPrices={prices}
+            addPriceAction={addPriceAction}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ListItemCard.test.tsx
+++ b/src/components/ListItemCard.test.tsx
@@ -32,6 +32,7 @@ window.confirm = mockConfirm;
 const mockItem: ListItemWithCategory = {
   id: "item-1",
   list_id: "list-1",
+  product_id: "product-1",
   name: "Milk",
   quantity: 2,
   unit: "L",
@@ -42,6 +43,7 @@ const mockItem: ListItemWithCategory = {
 const mockItemNoCategory: ListItemWithCategory = {
   id: "item-2",
   list_id: "list-1",
+  product_id: "product-2",
   name: "Bread",
   quantity: 1,
   unit: null,

--- a/src/components/ListItemCard.tsx
+++ b/src/components/ListItemCard.tsx
@@ -57,7 +57,7 @@ export function ListItemCard({
   const error = updateState.error || deleteState.error;
 
   return (
-    <div className="rounded-md border border-zinc-200 bg-white p-3">
+    <div className="p-3">
       {isEditing ? (
         // ─── Edit Mode ───
         <form action={updateFormAction} className="flex flex-col gap-2">

--- a/src/components/MergeProductForm.test.tsx
+++ b/src/components/MergeProductForm.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { MergeProductForm } from "./MergeProductForm";
+import type { Product } from "@/lib/types";
+
+// Mock useActionState
+const mockFormAction = jest.fn();
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useActionState: (action: unknown, initialState: unknown) => [
+    initialState,
+    mockFormAction,
+  ],
+}));
+
+// Mock useFormStatus used inside SubmitButton
+jest.mock("react-dom", () => ({
+  ...jest.requireActual("react-dom"),
+  useFormStatus: () => ({ pending: false }),
+}));
+
+const mockProducts: Product[] = [
+  { id: "product-1", user_id: "user-1", name: "Milk" },
+  { id: "product-2", user_id: "user-1", name: "Bread" },
+  { id: "product-3", user_id: "user-1", name: "Cheese" },
+];
+
+const mockMergeAction = jest.fn();
+const mockOnCancel = jest.fn();
+
+describe("MergeProductForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders dropdown excluding the source product", () => {
+    render(
+      <MergeProductForm
+        sourceId="product-1"
+        allProducts={mockProducts}
+        mergeAction={mockMergeAction}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const select = screen.getByRole("combobox");
+    const options = select.querySelectorAll("option");
+
+    // "Select product..." + Bread + Cheese (Milk excluded as source)
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveTextContent("Select product...");
+    expect(options[1]).toHaveTextContent("Bread");
+    expect(options[2]).toHaveTextContent("Cheese");
+  });
+
+  it("renders merge and cancel buttons", () => {
+    render(
+      <MergeProductForm
+        sourceId="product-1"
+        allProducts={mockProducts}
+        mergeAction={mockMergeAction}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Merge" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Cancel" })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/MergeProductForm.tsx
+++ b/src/components/MergeProductForm.tsx
@@ -1,0 +1,85 @@
+/**
+ * A small inline form to merge one product into another.
+ *
+ * Shows a dropdown of all other products. When submitted, all list items
+ * and prices from the source product are moved to the target, and the
+ * source is deleted. This is useful for cleaning up duplicates.
+ */
+"use client";
+
+import { useActionState } from "react";
+import { SubmitButton } from "@/components/SubmitButton";
+import type { ActionResult } from "@/app/(protected)/actions";
+import type { Product } from "@/lib/types";
+
+export function MergeProductForm({
+  sourceId,
+  allProducts,
+  mergeAction,
+  onCancel,
+}: {
+  /** The product being merged (will be deleted after merge) */
+  sourceId: string;
+  /** All products (used to pick the target — source is excluded) */
+  allProducts: Product[];
+  /** Server Action to merge the products */
+  mergeAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+  /** Called when the user cancels */
+  onCancel: () => void;
+}) {
+  const [state, formAction] = useActionState(
+    async (previousState: ActionResult, formData: FormData) => {
+      const result = await mergeAction(previousState, formData);
+      if (!result.error) {
+        onCancel();
+      }
+      return result;
+    },
+    { error: null }
+  );
+
+  // Exclude the source product from the dropdown
+  const targetOptions = allProducts.filter((p) => p.id !== sourceId);
+
+  return (
+    <div className="mt-2 rounded-md border border-zinc-200 bg-zinc-50 p-3">
+      <p className="mb-2 text-xs font-medium text-zinc-500">Merge into:</p>
+      <form action={formAction} className="flex gap-2">
+        <input type="hidden" name="source_id" value={sourceId} />
+        <select
+          name="target_id"
+          required
+          className="flex-1 rounded-md border border-zinc-300 px-3 py-1.5 text-sm text-zinc-700 focus:border-zinc-500 focus:outline-none"
+        >
+          <option value="">Select product...</option>
+          {targetOptions.map((product) => (
+            <option key={product.id} value={product.id}>
+              {product.name}
+            </option>
+          ))}
+        </select>
+        <SubmitButton
+          label="Merge"
+          pendingLabel="Merging..."
+          className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+        />
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm text-zinc-600 hover:bg-zinc-100"
+        >
+          Cancel
+        </button>
+      </form>
+
+      {state.error && (
+        <p className="mt-2 rounded-md bg-red-50 p-2 text-sm text-red-600">
+          {state.error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProductCard.test.tsx
+++ b/src/components/ProductCard.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ProductCard } from "./ProductCard";
+import type { ProductWithCounts } from "./ProductCard";
+import type { Product } from "@/lib/types";
+
+// Mock useActionState — ProductCard calls it twice (update + delete)
+const mockUpdateFormAction = jest.fn();
+const mockDeleteFormAction = jest.fn();
+let useActionStateCallCount = 0;
+
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useActionState: () => {
+    useActionStateCallCount++;
+    if (useActionStateCallCount % 2 === 1) {
+      return [{ error: null }, mockUpdateFormAction];
+    }
+    return [{ error: null }, mockDeleteFormAction];
+  },
+}));
+
+// Mock useFormStatus used inside SubmitButton
+jest.mock("react-dom", () => ({
+  ...jest.requireActual("react-dom"),
+  useFormStatus: () => ({ pending: false }),
+}));
+
+// Mock window.confirm
+const mockConfirm = jest.fn();
+window.confirm = mockConfirm;
+
+const mockProduct: ProductWithCounts = {
+  id: "product-1",
+  user_id: "user-1",
+  name: "Milk",
+  item_count: 3,
+  price_count: 2,
+};
+
+const mockAllProducts: Product[] = [
+  { id: "product-1", user_id: "user-1", name: "Milk" },
+  { id: "product-2", user_id: "user-1", name: "Bread" },
+];
+
+const mockUpdateAction = jest.fn();
+const mockDeleteAction = jest.fn();
+const mockMergeAction = jest.fn();
+
+describe("ProductCard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useActionStateCallCount = 0;
+  });
+
+  it("renders product name and counts in view mode", () => {
+    render(
+      <ProductCard
+        product={mockProduct}
+        prices={[]}
+        allProducts={mockAllProducts}
+        updateAction={mockUpdateAction}
+        deleteAction={mockDeleteAction}
+        mergeAction={mockMergeAction}
+      />
+    );
+
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+    expect(screen.getByText("3 items · 2 prices")).toBeInTheDocument();
+  });
+
+  it("renders edit, merge, and delete buttons", () => {
+    render(
+      <ProductCard
+        product={mockProduct}
+        prices={[]}
+        allProducts={mockAllProducts}
+        updateAction={mockUpdateAction}
+        deleteAction={mockDeleteAction}
+        mergeAction={mockMergeAction}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Edit Milk" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Merge" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Delete" })
+    ).toBeInTheDocument();
+  });
+
+  it("switches to edit mode when edit button is clicked", () => {
+    render(
+      <ProductCard
+        product={mockProduct}
+        prices={[]}
+        allProducts={mockAllProducts}
+        updateAction={mockUpdateAction}
+        deleteAction={mockDeleteAction}
+        mergeAction={mockMergeAction}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Milk" }));
+
+    expect(screen.getByDisplayValue("Milk")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Cancel" })
+    ).toBeInTheDocument();
+  });
+
+  it("exits edit mode when cancel is clicked", () => {
+    render(
+      <ProductCard
+        product={mockProduct}
+        prices={[]}
+        allProducts={mockAllProducts}
+        updateAction={mockUpdateAction}
+        deleteAction={mockDeleteAction}
+        mergeAction={mockMergeAction}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Milk" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Edit Milk" })
+    ).toBeInTheDocument();
+  });
+
+  it("shows confirm dialog when delete is clicked", () => {
+    mockConfirm.mockReturnValue(false);
+
+    render(
+      <ProductCard
+        product={mockProduct}
+        prices={[]}
+        allProducts={mockAllProducts}
+        updateAction={mockUpdateAction}
+        deleteAction={mockDeleteAction}
+        mergeAction={mockMergeAction}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      'Delete "Milk"? 3 item(s) will lose their prices.'
+    );
+  });
+
+  it("shows merge form when merge button is clicked", () => {
+    render(
+      <ProductCard
+        product={mockProduct}
+        prices={[]}
+        allProducts={mockAllProducts}
+        updateAction={mockUpdateAction}
+        deleteAction={mockDeleteAction}
+        mergeAction={mockMergeAction}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Merge" }));
+
+    expect(screen.getByText("Merge into:")).toBeInTheDocument();
+    expect(screen.getByText("Select product...")).toBeInTheDocument();
+  });
+});

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,0 +1,189 @@
+/**
+ * A card that displays a single product with view/edit/merge modes.
+ *
+ * Similar to StoreCard but with extra info:
+ * - Shows how many list items use this product
+ * - Shows how many prices are set for it
+ * - Has a "Merge" button to combine with another product
+ *
+ * Renaming a product also updates all list items that use it,
+ * so the display name stays in sync everywhere.
+ */
+"use client";
+
+import { useState, useActionState } from "react";
+import { SubmitButton } from "@/components/SubmitButton";
+import { MergeProductForm } from "@/components/MergeProductForm";
+import type { Product, ItemPriceWithStore } from "@/lib/types";
+import type { ActionResult } from "@/app/(protected)/actions";
+
+/** Product with usage counts, returned by the products page query */
+export type ProductWithCounts = Product & {
+  item_count: number;
+  price_count: number;
+};
+
+export function ProductCard({
+  product,
+  prices,
+  allProducts,
+  updateAction,
+  deleteAction,
+  mergeAction,
+}: {
+  /** The product to display (with counts) */
+  product: ProductWithCounts;
+  /** Prices for this product (with store names) */
+  prices: ItemPriceWithStore[];
+  /** All products (for the merge dropdown) */
+  allProducts: Product[];
+  /** Server Action to rename the product */
+  updateAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+  /** Server Action to delete the product */
+  deleteAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+  /** Server Action to merge products */
+  mergeAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [isMerging, setIsMerging] = useState(false);
+
+  const [updateState, updateFormAction] = useActionState(
+    async (previousState: ActionResult, formData: FormData) => {
+      const result = await updateAction(previousState, formData);
+      if (!result.error) {
+        setIsEditing(false);
+      }
+      return result;
+    },
+    { error: null }
+  );
+  const [deleteState, deleteFormAction] = useActionState(deleteAction, {
+    error: null,
+  });
+
+  const error = updateState.error || deleteState.error;
+
+  return (
+    <div className="rounded-md border border-zinc-200 bg-white p-3">
+      {isEditing ? (
+        // ─── Edit Mode ───
+        <form action={updateFormAction} className="flex gap-2">
+          <input type="hidden" name="id" value={product.id} />
+          <input
+            type="text"
+            name="name"
+            defaultValue={product.name}
+            required
+            autoFocus
+            className="flex-1 rounded-md border border-zinc-300 px-3 py-1.5 text-sm focus:border-zinc-500 focus:outline-none"
+          />
+          <SubmitButton
+            label="Save"
+            pendingLabel="Saving..."
+            className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+          />
+          <button
+            type="button"
+            onClick={() => setIsEditing(false)}
+            className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm text-zinc-600 hover:bg-zinc-100"
+          >
+            Cancel
+          </button>
+        </form>
+      ) : (
+        // ─── View Mode ───
+        <div>
+          <div className="flex items-center justify-between">
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-zinc-900">
+                {product.name}
+              </p>
+              <p className="text-xs text-zinc-400">
+                {product.item_count} item{product.item_count !== 1 ? "s" : ""}
+                {" · "}
+                {product.price_count} price{product.price_count !== 1 ? "s" : ""}
+              </p>
+              {/* Show store prices inline */}
+              {prices.length > 0 && (
+                <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
+                  {[...prices]
+                    .sort((a, b) => a.stores.name.localeCompare(b.stores.name))
+                    .map((p) => (
+                      <span key={p.id} className="text-xs text-zinc-500">
+                        {p.stores.name}: &euro;{Number(p.price).toFixed(2)}
+                      </span>
+                    ))}
+                </div>
+              )}
+            </div>
+
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => setIsEditing(true)}
+                className="rounded-md px-2 py-1 text-xs text-zinc-500 hover:bg-zinc-100"
+                aria-label={`Edit ${product.name}`}
+              >
+                Edit
+              </button>
+
+              <button
+                onClick={() => setIsMerging(!isMerging)}
+                className="rounded-md px-2 py-1 text-xs text-zinc-500 hover:bg-zinc-100"
+              >
+                Merge
+              </button>
+
+              <form
+                className="flex"
+                action={deleteFormAction}
+                onSubmit={(e) => {
+                  const message =
+                    product.item_count > 0
+                      ? `Delete "${product.name}"? ${product.item_count} item(s) will lose their prices.`
+                      : `Delete "${product.name}" and its prices?`;
+                  const confirmed = window.confirm(message);
+                  if (!confirmed) {
+                    e.preventDefault();
+                  }
+                }}
+              >
+                <input type="hidden" name="id" value={product.id} />
+                <button
+                  type="submit"
+                  className="rounded-md px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+                >
+                  Delete
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Merge form — shown below the card when "Merge" is clicked */}
+      {isMerging && (
+        <MergeProductForm
+          sourceId={product.id}
+          allProducts={allProducts}
+          mergeAction={mergeAction}
+          onCancel={() => setIsMerging(false)}
+        />
+      )}
+
+      {error && (
+        <p className="mt-2 rounded-md bg-red-50 p-2 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/StoreCard.test.tsx
+++ b/src/components/StoreCard.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { StoreCard } from "./StoreCard";
+import type { Store } from "@/lib/types";
+
+// Mock useActionState — returns [state, formAction]
+// StoreCard calls useActionState twice: first for update, then for delete
+const mockUpdateFormAction = jest.fn();
+const mockDeleteFormAction = jest.fn();
+let useActionStateCallCount = 0;
+
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useActionState: () => {
+    useActionStateCallCount++;
+    if (useActionStateCallCount % 2 === 1) {
+      return [{ error: null }, mockUpdateFormAction];
+    }
+    return [{ error: null }, mockDeleteFormAction];
+  },
+}));
+
+// Mock useFormStatus used inside SubmitButton
+jest.mock("react-dom", () => ({
+  ...jest.requireActual("react-dom"),
+  useFormStatus: () => ({ pending: false }),
+}));
+
+// Mock window.confirm
+const mockConfirm = jest.fn();
+window.confirm = mockConfirm;
+
+const mockStore: Store = {
+  id: "store-1",
+  user_id: "user-1",
+  name: "Lidl",
+};
+
+const mockUpdateAction = jest.fn();
+const mockDeleteAction = jest.fn();
+
+describe("StoreCard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useActionStateCallCount = 0;
+  });
+
+  it("renders the store name in view mode", () => {
+    render(
+      <StoreCard
+        store={mockStore}
+        updateAction={mockUpdateAction}
+        deleteAction={mockDeleteAction}
+      />
+    );
+
+    expect(screen.getByText("Lidl")).toBeInTheDocument();
+  });
+
+  it("renders edit and delete buttons", () => {
+    render(
+      <StoreCard
+        store={mockStore}
+        updateAction={mockUpdateAction}
+        deleteAction={mockDeleteAction}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Edit Lidl" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Delete" })
+    ).toBeInTheDocument();
+  });
+
+  it("switches to edit mode when edit button is clicked", () => {
+    render(
+      <StoreCard
+        store={mockStore}
+        updateAction={mockUpdateAction}
+        deleteAction={mockDeleteAction}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Lidl" }));
+
+    expect(screen.getByDisplayValue("Lidl")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Cancel" })
+    ).toBeInTheDocument();
+  });
+
+  it("exits edit mode when cancel is clicked", () => {
+    render(
+      <StoreCard
+        store={mockStore}
+        updateAction={mockUpdateAction}
+        deleteAction={mockDeleteAction}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Lidl" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByText("Lidl")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Edit Lidl" })
+    ).toBeInTheDocument();
+  });
+
+  it("shows confirm dialog when delete is clicked", () => {
+    mockConfirm.mockReturnValue(false);
+
+    render(
+      <StoreCard
+        store={mockStore}
+        updateAction={mockUpdateAction}
+        deleteAction={mockDeleteAction}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      'Delete "Lidl"? All prices at this store will also be deleted.'
+    );
+  });
+});

--- a/src/components/StoreCard.tsx
+++ b/src/components/StoreCard.tsx
@@ -1,0 +1,126 @@
+/**
+ * A card that displays a single store with view/edit modes.
+ *
+ * Same dual-mode pattern as ShoppingListCard:
+ * - View mode: shows store name + edit/delete buttons
+ * - Edit mode: input with save/cancel buttons
+ *
+ * Deleting a store also deletes all prices at that store (ON DELETE CASCADE),
+ * so the confirmation dialog warns the user about this.
+ */
+"use client";
+
+import { useState, useActionState } from "react";
+import { SubmitButton } from "@/components/SubmitButton";
+import type { Store } from "@/lib/types";
+import type { ActionResult } from "@/app/(protected)/actions";
+
+export function StoreCard({
+  store,
+  updateAction,
+  deleteAction,
+}: {
+  /** The store data to display */
+  store: Store;
+  /** Server Action to rename the store */
+  updateAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+  /** Server Action to delete the store */
+  deleteAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+
+  const [updateState, updateFormAction] = useActionState(
+    async (previousState: ActionResult, formData: FormData) => {
+      const result = await updateAction(previousState, formData);
+      if (!result.error) {
+        setIsEditing(false);
+      }
+      return result;
+    },
+    { error: null }
+  );
+  const [deleteState, deleteFormAction] = useActionState(deleteAction, {
+    error: null,
+  });
+
+  const error = updateState.error || deleteState.error;
+
+  return (
+    <div className="rounded-md border border-zinc-200 bg-white p-3">
+      {isEditing ? (
+        // ─── Edit Mode ───
+        <form action={updateFormAction} className="flex gap-2">
+          <input type="hidden" name="id" value={store.id} />
+          <input
+            type="text"
+            name="name"
+            defaultValue={store.name}
+            required
+            autoFocus
+            className="flex-1 rounded-md border border-zinc-300 px-3 py-1.5 text-sm focus:border-zinc-500 focus:outline-none"
+          />
+          <SubmitButton
+            label="Save"
+            pendingLabel="Saving..."
+            className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+          />
+          <button
+            type="button"
+            onClick={() => setIsEditing(false)}
+            className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm text-zinc-600 hover:bg-zinc-100"
+          >
+            Cancel
+          </button>
+        </form>
+      ) : (
+        // ─── View Mode ───
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-medium text-zinc-900">{store.name}</p>
+
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setIsEditing(true)}
+              className="rounded-md px-2 py-1 text-xs text-zinc-500 hover:bg-zinc-100"
+              aria-label={`Edit ${store.name}`}
+            >
+              Edit
+            </button>
+
+            <form
+              className="flex"
+              action={deleteFormAction}
+              onSubmit={(e) => {
+                const confirmed = window.confirm(
+                  `Delete "${store.name}"? All prices at this store will also be deleted.`
+                );
+                if (!confirmed) {
+                  e.preventDefault();
+                }
+              }}
+            >
+              <input type="hidden" name="id" value={store.id} />
+              <button
+                type="submit"
+                className="rounded-md px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+              >
+                Delete
+              </button>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <p className="mt-2 rounded-md bg-red-50 p-2 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/StoreForm.test.tsx
+++ b/src/components/StoreForm.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { StoreForm } from "./StoreForm";
+
+// Mock useActionState from React
+const mockFormAction = jest.fn();
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useActionState: (action: unknown, initialState: unknown) => [
+    initialState,
+    mockFormAction,
+  ],
+}));
+
+// Mock useFormStatus used inside SubmitButton
+jest.mock("react-dom", () => ({
+  ...jest.requireActual("react-dom"),
+  useFormStatus: () => ({ pending: false }),
+}));
+
+describe("StoreForm", () => {
+  const mockCreateAction = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the input and submit button", () => {
+    render(<StoreForm createAction={mockCreateAction} />);
+
+    expect(screen.getByPlaceholderText("Store name...")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+  });
+
+  it("has a required input field", () => {
+    render(<StoreForm createAction={mockCreateAction} />);
+
+    const input = screen.getByPlaceholderText("Store name...");
+    expect(input).toBeRequired();
+  });
+});

--- a/src/components/StoreForm.tsx
+++ b/src/components/StoreForm.tsx
@@ -1,0 +1,59 @@
+/**
+ * A form to create a new store.
+ *
+ * Same pattern as ShoppingListForm — uses useActionState to call a
+ * Server Action and clears the input after a successful submission.
+ */
+"use client";
+
+import { useActionState, useRef } from "react";
+import { SubmitButton } from "@/components/SubmitButton";
+import type { ActionResult } from "@/app/(protected)/actions";
+
+export function StoreForm({
+  createAction,
+}: {
+  /** The Server Action to call when the form is submitted */
+  createAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+}) {
+  const formRef = useRef<HTMLFormElement>(null);
+
+  async function handleAction(
+    previousState: ActionResult,
+    formData: FormData
+  ): Promise<ActionResult> {
+    const result = await createAction(previousState, formData);
+
+    if (result.error === null) {
+      formRef.current?.reset();
+    }
+
+    return result;
+  }
+
+  const [state, formAction] = useActionState(handleAction, { error: null });
+
+  return (
+    <div>
+      <form ref={formRef} action={formAction} className="flex gap-2">
+        <input
+          type="text"
+          name="name"
+          placeholder="Store name..."
+          required
+          className="flex-1 rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none"
+        />
+        <SubmitButton label="Add" pendingLabel="Adding..." />
+      </form>
+
+      {state.error && (
+        <p className="mt-2 rounded-md bg-red-50 p-3 text-sm text-red-600">
+          {state.error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,10 +22,18 @@ export type Category = {
   name: string;
 };
 
+/** A product — a real-world item the user buys (e.g., "Milk") */
+export type Product = {
+  id: string;
+  user_id: string;
+  name: string;
+};
+
 /** A list item as stored in the list_items table */
 export type ListItem = {
   id: string;
   list_id: string;
+  product_id: string | null; // links to a shared product for price lookup
   name: string;
   quantity: number;
   unit: string | null;
@@ -41,4 +49,30 @@ export type ListItem = {
  */
 export type ListItemWithCategory = ListItem & {
   categories: { name: string } | null;
+};
+
+/** A store as stored in the stores table */
+export type Store = {
+  id: string;
+  user_id: string;
+  name: string;
+};
+
+/** A price entry linking a product to a store */
+export type ItemPrice = {
+  id: string;
+  product_id: string;
+  store_id: string;
+  price: number;
+};
+
+/**
+ * An item price with the store name included.
+ *
+ * When we query Supabase with .select("*, stores(name)"), it joins the
+ * stores table and returns the result as a nested object. For example:
+ * { id: "...", product_id: "...", store_id: "...", price: 0.89, stores: { name: "Lidl" } }
+ */
+export type ItemPriceWithStore = ItemPrice & {
+  stores: { name: string };
 };

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -80,11 +80,48 @@ create policy "Users can delete own lists"
 
 
 -- ============================================
+-- PRODUCTS
+-- A "product" represents a real-world item the user buys (e.g., "Milk").
+-- Products are user-level — each user has their own product catalog.
+-- Prices are attached to products (not list items), so if "Milk" is in
+-- multiple lists, the prices are shared automatically.
+-- Products are created automatically when adding items to lists.
+-- ============================================
+create table products (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references auth.users(id) on delete cascade not null,
+  name text not null
+);
+
+alter table products enable row level security;
+
+create policy "Users can view own products"
+  on products for select
+  using (user_id = auth.uid());
+
+create policy "Users can insert own products"
+  on products for insert
+  with check (user_id = auth.uid());
+
+create policy "Users can update own products"
+  on products for update
+  using (user_id = auth.uid());
+
+create policy "Users can delete own products"
+  on products for delete
+  using (user_id = auth.uid());
+
+
+-- ============================================
 -- LIST ITEMS
 -- ============================================
 create table list_items (
   id uuid default gen_random_uuid() primary key,
   list_id uuid references shopping_lists(id) on delete cascade not null,
+  -- product_id links this list item to a shared product.
+  -- Prices are on the product, so all list items pointing to the same
+  -- product share the same prices automatically.
+  product_id uuid references products(id) on delete set null,
   name text not null,
   quantity numeric default 1 not null,
   unit text,
@@ -165,58 +202,58 @@ create policy "Users can delete own stores"
 
 -- ============================================
 -- ITEM PRICES
+-- Prices are linked to products (not list items), so they're shared
+-- across all lists that contain the same product.
 -- ============================================
 create table item_prices (
   id uuid default gen_random_uuid() primary key,
-  item_id uuid references list_items(id) on delete cascade not null,
+  product_id uuid references products(id) on delete cascade not null,
   store_id uuid references stores(id) on delete cascade not null,
-  price numeric not null check (price >= 0)
+  price numeric not null check (price >= 0),
+  -- Each product can only have one price per store
+  unique (product_id, store_id)
 );
 
 alter table item_prices enable row level security;
 
--- RLS joins through list_items → shopping_lists to check ownership
-create policy "Users can view prices for own items"
+-- RLS checks ownership through products.user_id
+create policy "Users can view prices for own products"
   on item_prices for select
   using (
     exists (
-      select 1 from list_items
-      join shopping_lists on shopping_lists.id = list_items.list_id
-      where list_items.id = item_prices.item_id
-        and shopping_lists.user_id = auth.uid()
+      select 1 from products
+      where products.id = item_prices.product_id
+        and products.user_id = auth.uid()
     )
   );
 
-create policy "Users can insert prices for own items"
+create policy "Users can insert prices for own products"
   on item_prices for insert
   with check (
     exists (
-      select 1 from list_items
-      join shopping_lists on shopping_lists.id = list_items.list_id
-      where list_items.id = item_prices.item_id
-        and shopping_lists.user_id = auth.uid()
+      select 1 from products
+      where products.id = item_prices.product_id
+        and products.user_id = auth.uid()
     )
   );
 
-create policy "Users can update prices for own items"
+create policy "Users can update prices for own products"
   on item_prices for update
   using (
     exists (
-      select 1 from list_items
-      join shopping_lists on shopping_lists.id = list_items.list_id
-      where list_items.id = item_prices.item_id
-        and shopping_lists.user_id = auth.uid()
+      select 1 from products
+      where products.id = item_prices.product_id
+        and products.user_id = auth.uid()
     )
   );
 
-create policy "Users can delete prices for own items"
+create policy "Users can delete prices for own products"
   on item_prices for delete
   using (
     exists (
-      select 1 from list_items
-      join shopping_lists on shopping_lists.id = list_items.list_id
-      where list_items.id = item_prices.item_id
-        and shopping_lists.user_id = auth.uid()
+      select 1 from products
+      where products.id = item_prices.product_id
+        and products.user_id = auth.uid()
     )
   );
 


### PR DESCRIPTION
## What
Add store management, per-item price tracking with shared products, and a product management page.

## Why
Phase 4 of the app — users need to compare prices across stores to find the best deals. Prices are shared via a products table so entering "Milk" in multiple lists automatically shows the same prices everywhere.

## Jira related ticket
- N/A

## Changes

### Stores (`/stores`)
- New stores CRUD page with StoreForm, StoreCard, EmptyStoreState components
- Server actions: createStore, updateStore, deleteStore

### Item Prices (on list detail page)
- Collapsible price section below each item showing store prices
- "Best: €X.XX at Store" summary when collapsed
- AddPriceForm with store dropdown (filters out stores that already have a price)
- ItemPriceRow with inline edit/delete (dual-mode pattern)
- Server actions: addPrice, updatePrice, deletePrice

### Shared Products
- New `products` table — created automatically when adding items
- `item_prices` linked to products (not list items), so prices are reusable across lists
- `list_items` gets `product_id` column linking to the shared product
- `findOrCreateProduct` helper does case-insensitive matching
- Auto-fills category from previous product usage

### Product Autocomplete
- AddItemForm now suggests matching existing products as you type (debounced client-side query)

### Products Page (`/products`)
- View all products with item count, price count, and store prices
- Rename products (also updates linked list item names)
- Merge duplicates (moves items + prices from source to target, handles conflicts)
- Delete unused products
- Server actions: updateProduct, deleteProduct, mergeProducts

### Navigation
- Header updated with Lists, Stores, Products nav links

### Schema
- New `products` table with RLS policies
- `list_items`: added `product_id` column
- `item_prices`: changed from `item_id` to `product_id` with updated RLS and unique constraint

## Testing
```bash
npm test          # 72 unit tests pass
npx playwright test  # 45 E2E tests pass
```

- E2E coverage: stores CRUD, item prices CRUD, products management (rename, merge, delete)
- Unit tests for all new components

## Checklist
- [x] All 72 unit tests pass
- [x] All 45 E2E tests pass
- [x] TypeScript compiles with no errors
- [x] Visual verification done