### PR TITLE
feat: add price comparison dashboard

### DIFF
--- a/src/app/(protected)/lists/[id]/compare/page.tsx
+++ b/src/app/(protected)/lists/[id]/compare/page.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { fetchListPageData } from "@/lib/list-data";
+import { calculateStoreTotals, calculateSmartSplit } from "@/lib/comparison";
+import { StoreTotalsSection } from "@/components/StoreTotalsSection";
+import { SmartSplitSection } from "@/components/SmartSplitSection";
+import { EmptyComparisonState } from "@/components/EmptyComparisonState";
+
+/**
+ * Price comparison page — shows how much a shopping list costs at
+ * each store and the smartest way to split purchases to save money.
+ *
+ * This is a Server Component — it fetches data on the server and
+ * renders the results. No client-side JavaScript needed since the
+ * dashboard is read-only (no forms, no toggles).
+ */
+export default async function ComparePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  // Reuse the same data fetching as the list detail page
+  const data = await fetchListPageData(id);
+
+  if (!data) {
+    notFound();
+  }
+
+  const { list, items, pricesByProduct, allDiscounts } = data;
+
+  // Run the comparison calculations
+  const storeTotals = calculateStoreTotals(
+    items,
+    pricesByProduct,
+    allDiscounts
+  );
+  const smartSplit = calculateSmartSplit(
+    items,
+    pricesByProduct,
+    allDiscounts,
+    storeTotals
+  );
+
+  // Check if there's anything to compare (at least one item with a price)
+  const hasData = storeTotals.length > 0;
+
+  return (
+    <div>
+      <Link
+        href={`/lists/${id}`}
+        className="text-sm text-zinc-500 hover:text-zinc-700"
+      >
+        &larr; Back to list
+      </Link>
+
+      <h2 className="mt-3 text-xl font-semibold">
+        Compare Prices: {list.name}
+      </h2>
+
+      {hasData ? (
+        <div className="mt-6 flex flex-col gap-8">
+          <StoreTotalsSection storeTotals={storeTotals} />
+          <SmartSplitSection smartSplit={smartSplit} />
+        </div>
+      ) : (
+        <EmptyComparisonState />
+      )}
+    </div>
+  );
+}

--- a/src/app/(protected)/lists/[id]/page.tsx
+++ b/src/app/(protected)/lists/[id]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
+import { fetchListPageData } from "@/lib/list-data";
 import { AddItemForm } from "@/components/AddItemForm";
 import { ListItemCard } from "@/components/ListItemCard";
 import { ItemPricesSection } from "@/components/ItemPricesSection";
@@ -17,7 +17,7 @@ import {
   updateDiscount,
   deleteDiscount,
 } from "@/app/(protected)/actions";
-import type { ListItemWithCategory, Store, ItemPriceWithStore, Discount } from "@/lib/types";
+import type { ListItemWithCategory } from "@/lib/types";
 
 /**
  * List detail page — shows a shopping list's items with the ability
@@ -37,109 +37,21 @@ export default async function ListDetailPage({
   // In Next.js 15+, params is a Promise that we need to await
   const { id } = await params;
 
-  const supabase = await createClient();
-
-  // Get the current user (needed to fetch their custom categories)
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  // Fetch this specific list — RLS ensures we can only see our own lists
-  const { data: list } = await supabase
-    .from("shopping_lists")
-    .select("*")
-    .eq("id", id)
-    .single();
+  // Fetch all list data using the shared helper (also used by the compare page)
+  const data = await fetchListPageData(id);
 
   // If the list doesn't exist (or doesn't belong to this user), show 404
-  if (!list) {
+  if (!data) {
     notFound();
   }
 
-  // Fetch all items in this list, joining the category name.
-  // .select("*, categories(name)") tells Supabase to include the related
-  // category row — it comes back as { categories: { name: "Fruits" } }
-  const { data: items } = await supabase
-    .from("list_items")
-    .select("*, categories(name)")
-    .eq("list_id", id)
-    .order("name");
-
-  // Fetch all categories this user can see: defaults (user_id is null)
-  // plus any custom ones they created (user_id matches their ID)
-  const { data: categories } = await supabase
-    .from("categories")
-    .select("*")
-    .or(`user_id.is.null,user_id.eq.${user?.id}`)
-    .order("name");
-
-  // Fetch all stores for the current user (needed for the price dropdowns)
-  const { data: stores } = await supabase
-    .from("stores")
-    .select("*")
-    .order("name");
-
-  // Fetch prices by product_id. Prices are on products (not list items),
-  // so they're shared across lists. We collect the product_ids from the
-  // items, then fetch all prices for those products.
-  const productIds = (items ?? [])
-    .map((i) => i.product_id)
-    .filter((id): id is string => id !== null);
-  const uniqueProductIds = [...new Set(productIds)];
-
-  const { data: prices } =
-    uniqueProductIds.length > 0
-      ? await supabase
-          .from("item_prices")
-          .select("*, stores(name)")
-          .in("product_id", uniqueProductIds)
-      : { data: [] };
-
-  // Group prices by product_id so we can pass each item's prices easily.
-  // Multiple items can share the same product (and thus the same prices).
-  const pricesByProduct = new Map<string, ItemPriceWithStore[]>();
-  for (const price of (prices ?? []) as ItemPriceWithStore[]) {
-    if (!pricesByProduct.has(price.product_id)) {
-      pricesByProduct.set(price.product_id, []);
-    }
-    pricesByProduct.get(price.product_id)!.push(price);
-  }
-
-  // Fetch discounts that could apply to the prices on this list.
-  // Two kinds fetched in parallel (they're independent queries):
-  // 1. Product-level discounts — target a specific price entry
-  // 2. Store-level discounts — apply to all products at a store
-  const priceIds = (prices ?? []).map((p) => p.id);
-  const storeIdsInPrices = [
-    ...new Set((prices ?? []).map((p) => p.store_id)),
-  ];
-
-  const [{ data: productDiscounts }, { data: storeDiscounts }] =
-    await Promise.all([
-      priceIds.length > 0
-        ? supabase
-            .from("discounts")
-            .select("*")
-            .in("item_price_id", priceIds)
-        : Promise.resolve({ data: [] }),
-      storeIdsInPrices.length > 0
-        ? supabase
-            .from("discounts")
-            .select("*")
-            .in("store_id", storeIdsInPrices)
-            .is("item_price_id", null)
-        : Promise.resolve({ data: [] }),
-    ]);
-
-  const allDiscounts = [
-    ...((productDiscounts ?? []) as Discount[]),
-    ...((storeDiscounts ?? []) as Discount[]),
-  ];
+  const { list, items, categories, stores, pricesByProduct, allDiscounts } =
+    data;
 
   // Group items by category name so we can render them in sections.
   // Items without a category go into "Uncategorized".
   const grouped = new Map<string, ListItemWithCategory[]>();
-  for (const item of (items ?? []) as ListItemWithCategory[]) {
+  for (const item of items) {
     const categoryName = item.categories?.name ?? "Uncategorized";
     if (!grouped.has(categoryName)) {
       grouped.set(categoryName, []);
@@ -163,13 +75,25 @@ export default async function ListDetailPage({
         &larr; Back to lists
       </Link>
 
-      <h2 className="mt-3 text-xl font-semibold">{list.name}</h2>
+      <div className="mt-3 flex items-center justify-between">
+        <h2 className="text-xl font-semibold">{list.name}</h2>
+
+        {/* Show "Compare Prices" link only when there are prices to compare */}
+        {pricesByProduct.size > 0 && (
+          <Link
+            href={`/lists/${id}/compare`}
+            className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-800"
+          >
+            Compare Prices
+          </Link>
+        )}
+      </div>
 
       {/* Form to add new items — always visible at the top */}
       <div className="mt-4">
         <AddItemForm
           listId={id}
-          categories={categories ?? []}
+          categories={categories}
           addItemAction={addItem}
           createCategoryAction={createCategory}
         />
@@ -177,7 +101,7 @@ export default async function ListDetailPage({
 
       {/* List items grouped by category, or empty state */}
       <div className="mt-6">
-        {(!items || items.length === 0) ? (
+        {items.length === 0 ? (
           <EmptyItemState />
         ) : (
           <div className="flex flex-col gap-6">
@@ -196,7 +120,7 @@ export default async function ListDetailPage({
                       {/* Item details (name, quantity, category, edit/delete) */}
                       <ListItemCard
                         item={item}
-                        categories={categories ?? []}
+                        categories={categories}
                         updateAction={updateItem}
                         deleteAction={deleteItem}
                       />
@@ -206,7 +130,7 @@ export default async function ListDetailPage({
                           productId={item.product_id}
                           listId={id}
                           prices={pricesByProduct.get(item.product_id) ?? []}
-                          stores={(stores ?? []) as Store[]}
+                          stores={stores}
                           discounts={allDiscounts}
                           addPriceAction={addPrice}
                           updatePriceAction={updatePrice}

--- a/src/components/EmptyComparisonState.tsx
+++ b/src/components/EmptyComparisonState.tsx
@@ -1,0 +1,18 @@
+/**
+ * Shown when a shopping list has no items with prices to compare.
+ *
+ * Same pattern as EmptyItemState — a simple presentational component
+ * with no interactivity, so it stays as a Server Component.
+ */
+export function EmptyComparisonState() {
+  return (
+    <div className="py-12 text-center">
+      <p className="text-lg font-medium text-zinc-400">
+        Nothing to compare yet
+      </p>
+      <p className="mt-1 text-sm text-zinc-400">
+        Add prices to your items to see which store is cheapest.
+      </p>
+    </div>
+  );
+}

--- a/src/components/SmartSplitSection.tsx
+++ b/src/components/SmartSplitSection.tsx
@@ -1,0 +1,112 @@
+/**
+ * Displays the "smart split" — the optimal way to split purchases
+ * across stores to get the lowest total price.
+ *
+ * Shows items grouped by the store they should be bought at, with
+ * subtotals per store and a grand total. If splitting saves money
+ * vs. buying everything at the cheapest single store, a savings
+ * badge is shown.
+ *
+ * This is a Server Component — it just renders data, no interactivity.
+ */
+
+import type { SmartSplitResult, SmartSplitItem, UnpricedItem } from "@/lib/comparison";
+
+/** Formats quantity and unit for display, e.g., "(2 kg)" or "(3)" */
+function QuantityLabel({ item }: { item: Pick<SmartSplitItem | UnpricedItem, "quantity" | "unit"> }) {
+  if (item.quantity <= 1 && !item.unit) return null;
+  return (
+    <span className="ml-1">
+      ({item.quantity}{item.unit ? ` ${item.unit}` : ""})
+    </span>
+  );
+}
+
+export function SmartSplitSection({
+  smartSplit,
+}: {
+  /** The smart split result from calculateSmartSplit */
+  smartSplit: SmartSplitResult;
+}) {
+  const { storeGroups, grandTotal, unpricedItems, savingsVsCheapest } =
+    smartSplit;
+
+  if (storeGroups.length === 0) return null;
+
+  return (
+    <section>
+      {/* Header with grand total and savings badge */}
+      <div className="flex items-center justify-between pr-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-zinc-400">
+          Smart Split
+        </h3>
+        <div className="flex items-center gap-2">
+          {savingsVsCheapest > 0 && (
+            <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+              Save &euro;{savingsVsCheapest.toFixed(2)}
+            </span>
+          )}
+          <span className="text-lg font-semibold">
+            &euro;{grandTotal.toFixed(2)}
+          </span>
+        </div>
+      </div>
+
+      {/* Store groups — each group shows which items to buy at that store */}
+      <div className="mt-2 flex flex-col gap-3">
+        {storeGroups.map((group) => (
+          <div
+            key={group.storeId}
+            className="rounded-md border border-zinc-200 bg-white"
+          >
+            {/* Store name and subtotal */}
+            <div className="flex items-center justify-between border-b border-zinc-100 px-3 py-2">
+              <span className="text-sm font-medium">{group.storeName}</span>
+              <span className="text-sm font-medium text-zinc-500">
+                &euro;{group.storeTotal.toFixed(2)}
+              </span>
+            </div>
+
+            {/* Items to buy at this store */}
+            <div className="divide-y divide-zinc-50 px-3">
+              {group.items.map((item, index) => (
+                <div
+                  key={`${item.storeId}-${item.itemName}-${index}`}
+                  className="flex items-center justify-between py-1.5"
+                >
+                  <span className="text-sm text-zinc-600">
+                    {item.itemName}
+                    <QuantityLabel item={item} />
+                  </span>
+                  <span className="text-sm text-zinc-500">
+                    &euro;{item.lineTotal.toFixed(2)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Unpriced items — shown when some items have no prices anywhere */}
+      {unpricedItems.length > 0 && (
+        <div className="mt-3 rounded-md border border-dashed border-zinc-300 bg-zinc-50 px-3 py-2">
+          <p className="text-xs font-medium text-zinc-400">
+            No prices available
+          </p>
+          <div className="mt-1 flex flex-col gap-0.5">
+            {unpricedItems.map((item, index) => (
+              <span
+                key={`${item.itemName}-${index}`}
+                className="text-sm text-zinc-400"
+              >
+                {item.itemName}
+                <QuantityLabel item={item} />
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/StoreTotalsSection.tsx
+++ b/src/components/StoreTotalsSection.tsx
@@ -1,0 +1,70 @@
+/**
+ * Displays the total cost of a shopping list at each store.
+ *
+ * Each store is shown as a card with its total cost, how many items
+ * it covers, and whether it has prices for every item in the list.
+ * The cheapest store gets a green "Cheapest" badge.
+ *
+ * This is a Server Component — it just renders data, no interactivity.
+ */
+
+import type { StoreTotalResult } from "@/lib/comparison";
+
+export function StoreTotalsSection({
+  storeTotals,
+}: {
+  /** Store totals sorted cheapest first (from calculateStoreTotals) */
+  storeTotals: StoreTotalResult[];
+}) {
+  if (storeTotals.length === 0) return null;
+
+  const cheapestId = storeTotals[0].storeId;
+
+  return (
+    <section>
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-zinc-400">
+        Store Totals
+      </h3>
+      <div className="mt-2 flex flex-col gap-2">
+        {storeTotals.map((store) => (
+          <div
+            key={store.storeId}
+            className={`rounded-md border p-3 ${
+              store.storeId === cheapestId
+                ? "border-green-300 bg-green-50"
+                : "border-zinc-200 bg-white"
+            }`}
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="font-medium">{store.storeName}</span>
+                {store.storeId === cheapestId && (
+                  <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                    Cheapest
+                  </span>
+                )}
+              </div>
+              <span className="text-lg font-semibold">
+                &euro;{store.total.toFixed(2)}
+              </span>
+            </div>
+
+            {/* Coverage info — how many items this store has prices for */}
+            <p className="mt-1 text-xs text-zinc-400">
+              {store.isComplete ? (
+                <span className="text-green-600">
+                  All {store.totalPriceableItems} items available
+                </span>
+              ) : (
+                <span className="text-amber-600">
+                  {store.itemsCovered} of {store.totalPriceableItems} items
+                  available
+                </span>
+              )}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/comparison.test.ts
+++ b/src/lib/comparison.test.ts
@@ -1,0 +1,345 @@
+import {
+  calculateStoreTotals,
+  calculateSmartSplit,
+} from "./comparison";
+import type { Discount, ItemPriceWithStore, ListItem } from "./types";
+
+// ─── Helper factories ───────────────────────────────────────────────
+
+function makeItem(overrides: Partial<ListItem> = {}): ListItem {
+  return {
+    id: "item1",
+    list_id: "list1",
+    product_id: "prod1",
+    name: "Milk",
+    quantity: 1,
+    unit: null,
+    category_id: null,
+    ...overrides,
+  };
+}
+
+function makePrice(
+  overrides: Partial<ItemPriceWithStore> = {}
+): ItemPriceWithStore {
+  return {
+    id: "price1",
+    product_id: "prod1",
+    store_id: "store1",
+    price: 1.0,
+    stores: { name: "Store A" },
+    ...overrides,
+  };
+}
+
+function makeDiscount(
+  overrides: Partial<Discount> & Pick<Discount, "type" | "value">
+): Discount {
+  return {
+    id: "d1",
+    user_id: "user1",
+    store_id: "store1",
+    item_price_id: null,
+    description: null,
+    ...overrides,
+  };
+}
+
+// ─── calculateStoreTotals ───────────────────────────────────────────
+
+describe("calculateStoreTotals", () => {
+  it("returns empty array when there are no priceable items", () => {
+    const items = [makeItem({ product_id: null })];
+    const result = calculateStoreTotals(items, new Map(), []);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when there are no items", () => {
+    const result = calculateStoreTotals([], new Map(), []);
+    expect(result).toEqual([]);
+  });
+
+  it("calculates total for a single item at one store", () => {
+    const items = [makeItem({ quantity: 2 })];
+    const prices = new Map([
+      ["prod1", [makePrice({ price: 1.5 })]],
+    ]);
+
+    const result = calculateStoreTotals(items, prices, []);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].storeName).toBe("Store A");
+    expect(result[0].total).toBe(3.0); // 1.50 × 2
+    expect(result[0].itemsCovered).toBe(1);
+    expect(result[0].isComplete).toBe(true);
+  });
+
+  it("sorts stores cheapest first", () => {
+    const items = [makeItem()];
+    const prices = new Map([
+      [
+        "prod1",
+        [
+          makePrice({ id: "p1", store_id: "store1", price: 2.0, stores: { name: "Expensive" } }),
+          makePrice({ id: "p2", store_id: "store2", price: 1.0, stores: { name: "Cheap" } }),
+        ],
+      ],
+    ]);
+
+    const result = calculateStoreTotals(items, prices, []);
+
+    expect(result[0].storeName).toBe("Cheap");
+    expect(result[0].total).toBe(1.0);
+    expect(result[1].storeName).toBe("Expensive");
+    expect(result[1].total).toBe(2.0);
+  });
+
+  it("multiplies by quantity", () => {
+    const items = [makeItem({ quantity: 3 })];
+    const prices = new Map([["prod1", [makePrice({ price: 2.0 })]]]);
+
+    const result = calculateStoreTotals(items, prices, []);
+    expect(result[0].total).toBe(6.0); // 2.00 × 3
+  });
+
+  it("applies discounts before multiplying by quantity", () => {
+    const items = [makeItem({ quantity: 2 })];
+    const prices = new Map([["prod1", [makePrice({ price: 10.0 })]]]);
+    const discounts = [
+      makeDiscount({ type: "percentage", value: 10, store_id: "store1" }),
+    ];
+
+    const result = calculateStoreTotals(items, prices, discounts);
+    // 10.00 × 0.90 = 9.00 per unit × 2 = 18.00
+    expect(result[0].total).toBe(18.0);
+  });
+
+  it("marks stores with partial coverage as incomplete", () => {
+    const items = [
+      makeItem({ id: "i1", product_id: "prod1", name: "Milk" }),
+      makeItem({ id: "i2", product_id: "prod2", name: "Bread" }),
+    ];
+    // Store A only has Milk, not Bread
+    const prices = new Map([
+      ["prod1", [makePrice({ store_id: "store1", stores: { name: "Store A" } })]],
+    ]);
+
+    const result = calculateStoreTotals(items, prices, []);
+
+    expect(result[0].itemsCovered).toBe(1);
+    expect(result[0].totalPriceableItems).toBe(2);
+    expect(result[0].isComplete).toBe(false);
+  });
+
+  it("sums totals across multiple items", () => {
+    const items = [
+      makeItem({ id: "i1", product_id: "prod1", name: "Milk", quantity: 1 }),
+      makeItem({ id: "i2", product_id: "prod2", name: "Bread", quantity: 2 }),
+    ];
+    const prices = new Map([
+      ["prod1", [makePrice({ id: "p1", product_id: "prod1", price: 1.0 })]],
+      ["prod2", [makePrice({ id: "p2", product_id: "prod2", price: 0.5 })]],
+    ]);
+
+    const result = calculateStoreTotals(items, prices, []);
+    // Milk: 1.00 × 1 + Bread: 0.50 × 2 = 2.00
+    expect(result[0].total).toBe(2.0);
+    expect(result[0].isComplete).toBe(true);
+  });
+
+  it("ignores items without a product_id", () => {
+    const items = [
+      makeItem({ id: "i1", product_id: "prod1" }),
+      makeItem({ id: "i2", product_id: null, name: "Custom item" }),
+    ];
+    const prices = new Map([["prod1", [makePrice()]]]);
+
+    const result = calculateStoreTotals(items, prices, []);
+    // Only 1 priceable item, and it's covered
+    expect(result[0].totalPriceableItems).toBe(1);
+    expect(result[0].isComplete).toBe(true);
+  });
+});
+
+// ─── calculateSmartSplit ────────────────────────────────────────────
+
+describe("calculateSmartSplit", () => {
+  it("assigns a single item to the cheapest store", () => {
+    const items = [makeItem()];
+    const prices = new Map([
+      [
+        "prod1",
+        [
+          makePrice({ id: "p1", store_id: "store1", price: 2.0, stores: { name: "Expensive" } }),
+          makePrice({ id: "p2", store_id: "store2", price: 1.0, stores: { name: "Cheap" } }),
+        ],
+      ],
+    ]);
+
+    const storeTotals = calculateStoreTotals(items, prices, []);
+    const result = calculateSmartSplit(items, prices, [], storeTotals);
+
+    expect(result.storeGroups).toHaveLength(1);
+    expect(result.storeGroups[0].storeName).toBe("Cheap");
+    expect(result.storeGroups[0].items).toHaveLength(1);
+    expect(result.grandTotal).toBe(1.0);
+  });
+
+  it("splits items across stores when different stores are cheapest", () => {
+    const items = [
+      makeItem({ id: "i1", product_id: "prod1", name: "Milk" }),
+      makeItem({ id: "i2", product_id: "prod2", name: "Bread" }),
+    ];
+    const prices = new Map([
+      [
+        "prod1",
+        [
+          makePrice({ id: "p1", store_id: "store1", product_id: "prod1", price: 1.0, stores: { name: "Store A" } }),
+          makePrice({ id: "p2", store_id: "store2", product_id: "prod1", price: 2.0, stores: { name: "Store B" } }),
+        ],
+      ],
+      [
+        "prod2",
+        [
+          makePrice({ id: "p3", store_id: "store1", product_id: "prod2", price: 3.0, stores: { name: "Store A" } }),
+          makePrice({ id: "p4", store_id: "store2", product_id: "prod2", price: 1.0, stores: { name: "Store B" } }),
+        ],
+      ],
+    ]);
+
+    const storeTotals = calculateStoreTotals(items, prices, []);
+    const result = calculateSmartSplit(items, prices, [], storeTotals);
+
+    // Milk → Store A (€1), Bread → Store B (€1)
+    expect(result.storeGroups).toHaveLength(2);
+    expect(result.grandTotal).toBe(2.0);
+
+    const storeA = result.storeGroups.find((g) => g.storeName === "Store A")!;
+    expect(storeA.items[0].itemName).toBe("Milk");
+
+    const storeB = result.storeGroups.find((g) => g.storeName === "Store B")!;
+    expect(storeB.items[0].itemName).toBe("Bread");
+  });
+
+  it("puts items without product_id in unpricedItems", () => {
+    const items = [makeItem({ product_id: null, name: "Custom item" })];
+
+    const storeTotals = calculateStoreTotals(items, new Map(), []);
+    const result = calculateSmartSplit(items, new Map(), [], storeTotals);
+
+    expect(result.storeGroups).toHaveLength(0);
+    expect(result.unpricedItems).toHaveLength(1);
+    expect(result.unpricedItems[0].itemName).toBe("Custom item");
+  });
+
+  it("puts items with no prices anywhere in unpricedItems", () => {
+    const items = [makeItem()];
+    // product_id is "prod1" but no prices exist for it
+    const storeTotals = calculateStoreTotals(items, new Map(), []);
+    const result = calculateSmartSplit(items, new Map(), [], storeTotals);
+
+    expect(result.unpricedItems).toHaveLength(1);
+    expect(result.unpricedItems[0].itemName).toBe("Milk");
+  });
+
+  it("considers discounts when picking the cheapest store", () => {
+    const items = [makeItem()];
+    const prices = new Map([
+      [
+        "prod1",
+        [
+          // Store A: €2.00 but with 50% off → €1.00
+          makePrice({ id: "p1", store_id: "store1", price: 2.0, stores: { name: "Store A" } }),
+          // Store B: €1.50 with no discount → €1.50
+          makePrice({ id: "p2", store_id: "store2", price: 1.5, stores: { name: "Store B" } }),
+        ],
+      ],
+    ]);
+    const discounts = [
+      makeDiscount({ type: "percentage", value: 50, store_id: "store1" }),
+    ];
+
+    const storeTotals = calculateStoreTotals(items, prices, discounts);
+    const result = calculateSmartSplit(items, prices, discounts, storeTotals);
+
+    // Store A is cheaper after discount
+    expect(result.storeGroups[0].storeName).toBe("Store A");
+    expect(result.grandTotal).toBe(1.0);
+  });
+
+  it("multiplies by quantity in line totals", () => {
+    const items = [makeItem({ quantity: 3 })];
+    const prices = new Map([["prod1", [makePrice({ price: 2.0 })]]]);
+
+    const storeTotals = calculateStoreTotals(items, prices, []);
+    const result = calculateSmartSplit(items, prices, [], storeTotals);
+    expect(result.storeGroups[0].items[0].unitPrice).toBe(2.0);
+    expect(result.storeGroups[0].items[0].lineTotal).toBe(6.0);
+    expect(result.grandTotal).toBe(6.0);
+  });
+
+  it("calculates savings vs cheapest complete single store", () => {
+    const items = [
+      makeItem({ id: "i1", product_id: "prod1", name: "Milk" }),
+      makeItem({ id: "i2", product_id: "prod2", name: "Bread" }),
+    ];
+    const prices = new Map([
+      [
+        "prod1",
+        [
+          makePrice({ id: "p1", store_id: "store1", product_id: "prod1", price: 1.0, stores: { name: "Store A" } }),
+          makePrice({ id: "p2", store_id: "store2", product_id: "prod1", price: 3.0, stores: { name: "Store B" } }),
+        ],
+      ],
+      [
+        "prod2",
+        [
+          makePrice({ id: "p3", store_id: "store1", product_id: "prod2", price: 4.0, stores: { name: "Store A" } }),
+          makePrice({ id: "p4", store_id: "store2", product_id: "prod2", price: 2.0, stores: { name: "Store B" } }),
+        ],
+      ],
+    ]);
+
+    const storeTotals = calculateStoreTotals(items, prices, []);
+    const result = calculateSmartSplit(items, prices, [], storeTotals);
+
+    // Smart split: Milk → Store A (€1), Bread → Store B (€2) = €3 total
+    // Cheapest complete store: Store A (€1 + €4 = €5) or Store B (€3 + €2 = €5)
+    // Both are €5, savings = €5 - €3 = €2
+    expect(result.grandTotal).toBe(3.0);
+    expect(result.savingsVsCheapest).toBe(2.0);
+  });
+
+  it("returns zero savings when no complete store exists", () => {
+    const items = [
+      makeItem({ id: "i1", product_id: "prod1", name: "Milk" }),
+      makeItem({ id: "i2", product_id: "prod2", name: "Bread" }),
+    ];
+    // Each store only has one of the two items
+    const prices = new Map([
+      ["prod1", [makePrice({ id: "p1", store_id: "store1", product_id: "prod1", stores: { name: "Store A" } })]],
+      ["prod2", [makePrice({ id: "p2", store_id: "store2", product_id: "prod2", stores: { name: "Store B" } })]],
+    ]);
+
+    const storeTotals = calculateStoreTotals(items, prices, []);
+    const result = calculateSmartSplit(items, prices, [], storeTotals);
+    expect(result.savingsVsCheapest).toBe(0);
+  });
+
+  it("sorts store groups by store name", () => {
+    const items = [
+      makeItem({ id: "i1", product_id: "prod1", name: "Milk" }),
+      makeItem({ id: "i2", product_id: "prod2", name: "Bread" }),
+    ];
+    const prices = new Map([
+      ["prod1", [makePrice({ id: "p1", store_id: "store2", product_id: "prod1", price: 1.0, stores: { name: "Zebra" } })]],
+      ["prod2", [makePrice({ id: "p2", store_id: "store1", product_id: "prod2", price: 1.0, stores: { name: "Alpha" } })]],
+    ]);
+
+    const storeTotals = calculateStoreTotals(items, prices, []);
+    const result = calculateSmartSplit(items, prices, [], storeTotals);
+
+    expect(result.storeGroups[0].storeName).toBe("Alpha");
+    expect(result.storeGroups[1].storeName).toBe("Zebra");
+  });
+});

--- a/src/lib/comparison.ts
+++ b/src/lib/comparison.ts
@@ -1,0 +1,277 @@
+/**
+ * Price comparison and smart split calculations.
+ *
+ * These pure functions power the "Compare Prices" dashboard (Phase 6).
+ * They figure out:
+ * 1. How much a shopping list costs at each store (with discounts)
+ * 2. The smartest way to split purchases across stores to save money
+ *
+ * Both functions reuse the discount helpers from discounts.ts — they
+ * handle the per-item math, while this file handles the list-wide totals.
+ */
+
+import {
+  calculateDiscountedPrice,
+  getApplicableDiscounts,
+} from "@/lib/discounts";
+import type { Discount, ItemPriceWithStore, ListItem } from "@/lib/types";
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+/** The total cost of a shopping list at a single store */
+export type StoreTotalResult = {
+  storeId: string;
+  storeName: string;
+  /** Total cost after discounts, multiplied by quantities */
+  total: number;
+  /** How many list items this store has prices for */
+  itemsCovered: number;
+  /** Total items that could have prices (have a product_id) */
+  totalPriceableItems: number;
+  /** True if this store has prices for every priceable item */
+  isComplete: boolean;
+};
+
+/** One item's assignment in the smart split */
+export type SmartSplitItem = {
+  itemName: string;
+  quantity: number;
+  unit: string | null;
+  storeName: string;
+  storeId: string;
+  /** Discounted price per unit */
+  unitPrice: number;
+  /** unitPrice × quantity */
+  lineTotal: number;
+};
+
+/** An item that has no price at any store */
+export type UnpricedItem = {
+  itemName: string;
+  quantity: number;
+  unit: string | null;
+};
+
+/** The full result of a smart split calculation */
+export type SmartSplitResult = {
+  /** Items grouped by the store they should be bought at */
+  storeGroups: {
+    storeId: string;
+    storeName: string;
+    items: SmartSplitItem[];
+    /** Sum of all line totals for this store */
+    storeTotal: number;
+  }[];
+  /** Grand total across all stores */
+  grandTotal: number;
+  /** Items that couldn't be assigned (no prices anywhere) */
+  unpricedItems: UnpricedItem[];
+  /** How much cheaper the smart split is vs. the cheapest single store */
+  savingsVsCheapest: number;
+};
+
+// ─── calculateStoreTotals ───────────────────────────────────────────
+
+/**
+ * Calculate the total cost of a shopping list at each store.
+ *
+ * How it works:
+ * 1. Find all stores that appear in the price data
+ * 2. For each store, loop through every list item that has a product_id
+ * 3. If the store has a price for that product, apply discounts and
+ *    multiply by quantity to get the line total
+ * 4. Sum up all line totals for the store's grand total
+ *
+ * Stores with zero matching items are excluded from the results.
+ * Results are sorted cheapest first.
+ *
+ * @param items - The list items (only those with product_id are counted)
+ * @param pricesByProduct - Map of product_id → prices at various stores
+ * @param allDiscounts - All discounts that could apply
+ * @returns Store totals sorted by total ascending (cheapest first)
+ */
+export function calculateStoreTotals(
+  items: ListItem[],
+  pricesByProduct: Map<string, ItemPriceWithStore[]>,
+  allDiscounts: Discount[]
+): StoreTotalResult[] {
+  // Only items with a product_id can have prices
+  const priceableItems = items.filter((item) => item.product_id !== null);
+  const totalPriceableItems = priceableItems.length;
+
+  if (totalPriceableItems === 0) return [];
+
+  // Collect all unique stores from the price data.
+  // We use a Map so we can look up store names by ID later.
+  const storeMap = new Map<string, string>();
+  for (const prices of pricesByProduct.values()) {
+    for (const price of prices) {
+      storeMap.set(price.store_id, price.stores.name);
+    }
+  }
+
+  const results: StoreTotalResult[] = [];
+
+  for (const [storeId, storeName] of storeMap) {
+    let total = 0;
+    let itemsCovered = 0;
+
+    for (const item of priceableItems) {
+      const prices = pricesByProduct.get(item.product_id!) ?? [];
+      const priceAtStore = prices.find((p) => p.store_id === storeId);
+
+      if (priceAtStore) {
+        // Apply discounts to the unit price, then multiply by quantity
+        const discounts = getApplicableDiscounts(priceAtStore, allDiscounts);
+        const discountedUnitPrice = calculateDiscountedPrice(
+          Number(priceAtStore.price),
+          discounts
+        );
+        total += discountedUnitPrice * Number(item.quantity);
+        itemsCovered++;
+      }
+    }
+
+    // Only include stores that have at least one matching item
+    if (itemsCovered > 0) {
+      results.push({
+        storeId,
+        storeName,
+        total,
+        itemsCovered,
+        totalPriceableItems,
+        isComplete: itemsCovered === totalPriceableItems,
+      });
+    }
+  }
+
+  // Sort cheapest first
+  results.sort((a, b) => a.total - b.total);
+
+  return results;
+}
+
+// ─── calculateSmartSplit ────────────────────────────────────────────
+
+/**
+ * Calculate the optimal way to split a shopping list across stores.
+ *
+ * The "smart split" strategy is simple: for each item, buy it at
+ * whichever store offers the lowest discounted price. This gives the
+ * absolute cheapest total, even if it means visiting multiple stores.
+ *
+ * How it works:
+ * 1. For each item with a product_id, find all its prices
+ * 2. Calculate the discounted unit price at each store
+ * 3. Pick the store with the lowest discounted price
+ * 4. Multiply by quantity for the line total
+ * 5. Group all items by their assigned store
+ * 6. Compare the grand total to the cheapest single-store total
+ *    to show how much the split saves
+ *
+ * Items without a product_id or without any prices go into the
+ * "unpriced" list — they can't be part of the comparison.
+ *
+ * @param items - The list items
+ * @param pricesByProduct - Map of product_id → prices at various stores
+ * @param allDiscounts - All discounts that could apply
+ * @param storeTotals - Pre-computed store totals (from calculateStoreTotals)
+ *   so we don't recalculate them — the caller typically needs both results
+ * @returns The optimal split with savings info
+ */
+export function calculateSmartSplit(
+  items: ListItem[],
+  pricesByProduct: Map<string, ItemPriceWithStore[]>,
+  allDiscounts: Discount[],
+  storeTotals: StoreTotalResult[]
+): SmartSplitResult {
+  const assignments: SmartSplitItem[] = [];
+  const unpricedItems: UnpricedItem[] = [];
+
+  for (const item of items) {
+    // Items without a product link can't have prices
+    if (!item.product_id) {
+      unpricedItems.push({
+        itemName: item.name,
+        quantity: Number(item.quantity),
+        unit: item.unit,
+      });
+      continue;
+    }
+
+    const prices = pricesByProduct.get(item.product_id) ?? [];
+
+    if (prices.length === 0) {
+      unpricedItems.push({
+        itemName: item.name,
+        quantity: Number(item.quantity),
+        unit: item.unit,
+      });
+      continue;
+    }
+
+    // Find the store with the cheapest discounted unit price
+    let cheapestPrice: ItemPriceWithStore | null = null;
+    let cheapestDiscounted = Infinity;
+
+    for (const price of prices) {
+      const discounts = getApplicableDiscounts(price, allDiscounts);
+      const discounted = calculateDiscountedPrice(
+        Number(price.price),
+        discounts
+      );
+      if (discounted < cheapestDiscounted) {
+        cheapestDiscounted = discounted;
+        cheapestPrice = price;
+      }
+    }
+
+    if (cheapestPrice) {
+      assignments.push({
+        itemName: item.name,
+        quantity: Number(item.quantity),
+        unit: item.unit,
+        storeName: cheapestPrice.stores.name,
+        storeId: cheapestPrice.store_id,
+        unitPrice: cheapestDiscounted,
+        lineTotal: cheapestDiscounted * Number(item.quantity),
+      });
+    }
+  }
+
+  // Group assignments by store ID
+  const groupMap = new Map<string, SmartSplitItem[]>();
+  for (const item of assignments) {
+    if (!groupMap.has(item.storeId)) {
+      groupMap.set(item.storeId, []);
+    }
+    groupMap.get(item.storeId)!.push(item);
+  }
+
+  // Build store groups sorted by store name
+  const storeGroups = [...groupMap.entries()]
+    .map(([storeId, groupItems]) => ({
+      storeId,
+      storeName: groupItems[0].storeName,
+      items: groupItems.sort((a, b) => a.itemName.localeCompare(b.itemName)),
+      storeTotal: groupItems.reduce((sum, item) => sum + item.lineTotal, 0),
+    }))
+    .sort((a, b) => a.storeName.localeCompare(b.storeName));
+
+  const grandTotal = storeGroups.reduce((sum, g) => sum + g.storeTotal, 0);
+
+  // Compare against the cheapest single store to show savings.
+  // We only compare to "complete" stores (ones that have all items),
+  // because a partial store can't actually fulfill the whole list.
+  const cheapestComplete = storeTotals.find((s) => s.isComplete);
+  const savingsVsCheapest = cheapestComplete
+    ? cheapestComplete.total - grandTotal
+    : 0;
+
+  return {
+    storeGroups,
+    grandTotal,
+    unpricedItems,
+    savingsVsCheapest,
+  };
+}

--- a/src/lib/list-data.ts
+++ b/src/lib/list-data.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared data fetching for shopping list pages.
+ *
+ * Both the list detail page (/lists/[id]) and the compare page
+ * (/lists/[id]/compare) need the same data: list info, items, stores,
+ * prices grouped by product, and discounts. This file extracts that
+ * shared logic so we don't duplicate ~50 lines of Supabase queries.
+ *
+ * Why a separate file? The DRY principle — if we ever change how
+ * prices or discounts are fetched (e.g., adding a new join), we only
+ * need to update one place.
+ */
+
+import { createClient } from "@/lib/supabase/server";
+import type {
+  ShoppingList,
+  ListItemWithCategory,
+  Category,
+  Store,
+  ItemPriceWithStore,
+  Discount,
+} from "@/lib/types";
+
+/** Everything both pages need about a shopping list */
+export type ListPageData = {
+  list: ShoppingList;
+  items: ListItemWithCategory[];
+  categories: Category[];
+  stores: Store[];
+  pricesByProduct: Map<string, ItemPriceWithStore[]>;
+  allDiscounts: Discount[];
+};
+
+/**
+ * Fetch all data needed to display or compare a shopping list.
+ *
+ * Returns null if the list doesn't exist or doesn't belong to the
+ * current user (Supabase RLS handles the access check).
+ */
+export async function fetchListPageData(
+  listId: string
+): Promise<ListPageData | null> {
+  const supabase = await createClient();
+
+  // Get the current user (needed for category filtering)
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Fetch the list — RLS ensures we can only see our own
+  const { data: list } = await supabase
+    .from("shopping_lists")
+    .select("*")
+    .eq("id", listId)
+    .single();
+
+  if (!list) return null;
+
+  // Fetch items, categories, and stores in parallel (independent queries)
+  const [{ data: items }, { data: categories }, { data: stores }] =
+    await Promise.all([
+      supabase
+        .from("list_items")
+        .select("*, categories(name)")
+        .eq("list_id", listId)
+        .order("name"),
+      supabase
+        .from("categories")
+        .select("*")
+        .or(`user_id.is.null,user_id.eq.${user?.id}`)
+        .order("name"),
+      supabase.from("stores").select("*").order("name"),
+    ]);
+
+  // Collect unique product IDs from the items (only items with a product link)
+  const productIds = (items ?? [])
+    .map((i) => i.product_id)
+    .filter((id): id is string => id !== null);
+  const uniqueProductIds = [...new Set(productIds)];
+
+  // Fetch prices for all products in the list
+  const { data: prices } =
+    uniqueProductIds.length > 0
+      ? await supabase
+          .from("item_prices")
+          .select("*, stores(name)")
+          .in("product_id", uniqueProductIds)
+      : { data: [] };
+
+  // Group prices by product_id for easy lookup
+  const pricesByProduct = new Map<string, ItemPriceWithStore[]>();
+  for (const price of (prices ?? []) as ItemPriceWithStore[]) {
+    if (!pricesByProduct.has(price.product_id)) {
+      pricesByProduct.set(price.product_id, []);
+    }
+    pricesByProduct.get(price.product_id)!.push(price);
+  }
+
+  // Fetch discounts: product-level and store-level in parallel
+  const priceIds = (prices ?? []).map((p) => p.id);
+  const storeIdsInPrices = [
+    ...new Set((prices ?? []).map((p) => p.store_id)),
+  ];
+
+  const [{ data: productDiscounts }, { data: storeDiscounts }] =
+    await Promise.all([
+      priceIds.length > 0
+        ? supabase
+            .from("discounts")
+            .select("*")
+            .in("item_price_id", priceIds)
+        : Promise.resolve({ data: [] }),
+      storeIdsInPrices.length > 0
+        ? supabase
+            .from("discounts")
+            .select("*")
+            .in("store_id", storeIdsInPrices)
+            .is("item_price_id", null)
+        : Promise.resolve({ data: [] }),
+    ]);
+
+  const allDiscounts = [
+    ...((productDiscounts ?? []) as Discount[]),
+    ...((storeDiscounts ?? []) as Discount[]),
+  ];
+
+  return {
+    list: list as ShoppingList,
+    items: (items ?? []) as ListItemWithCategory[],
+    categories: (categories ?? []) as Category[],
+    stores: (stores ?? []) as Store[],
+    pricesByProduct,
+    allDiscounts,
+  };
+}


### PR DESCRIPTION
## What
Add a price comparison dashboard that shows store totals and a smart split recommendation for each shopping list.

## Why
Phase 6 of the project — users need to see where to buy each item to save the most money, both at a single store and by splitting purchases across stores.

## Jira related ticket
- N/A

## Changes
- Add `src/lib/comparison.ts` with `calculateStoreTotals` and `calculateSmartSplit` pure calculation functions
- Add `src/lib/comparison.test.ts` with 18 unit tests covering store totals, smart split, discounts, partial coverage, and edge cases
- Add `src/lib/list-data.ts` to extract shared data fetching logic (used by both list detail and compare pages)
- Add compare page at `/lists/[id]/compare` with store totals and smart split sections
- Add `StoreTotalsSection`, `SmartSplitSection`, and `EmptyComparisonState` components
- Refactor list detail page to use shared `fetchListPageData` helper
- Add "Compare Prices" button on list detail page (only shown when prices exist)

## Testing
- `npm test` — 103 unit tests pass (18 new for comparison logic)
- `npm run build` — builds successfully, `/lists/[id]/compare` route registered
- Manual: create a list with items, add prices at 2+ stores, click "Compare Prices" to verify totals and smart split

## Screenshot
N/A

## Checklist
- `npm test` passes
- `npm run build` passes
- Visual verification done