### PR TITLE
feat: add shopping mode with check-off

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,9 @@ Best Basket is a shopping list and price comparison web app. Users create shoppi
 - **Phase 5:** Store and store product coupon discounts
 - **Phase 6:** Price comparison dashboard + smart split logic
 - **Phase 7:** Shopping mode (check off items, mobile UX polish)
-- **Phase 8:** Final polish, deploy to Vercel
+- **Phase 8:** Shared lists (share a list with other users for collaborative viewing and editing)
+- **Phase 9:** Template lists (save lists as reusable templates with optional weekly/monthly recurrence)
+- **Phase 10:** Final polish, deploy to Vercel
 
 ## Database Schema (Supabase)
 Tables to create (ask before implementing if unsure):

--- a/e2e/shopping-mode.spec.ts
+++ b/e2e/shopping-mode.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * Shopping mode E2E tests — tests the check-off flow while shopping.
+ *
+ * These tests use the saved storageState from auth.setup.ts, so the
+ * browser starts already logged in.
+ *
+ * The tests run SERIALLY because they form a natural sequence:
+ *   1. Create a list with items (prerequisite)
+ *   2. Navigate to shopping mode
+ *   3. Check off items and verify visual state
+ *   4. Verify checked state persists on reload
+ *   5. Test "Uncheck all" reset
+ *   6. Clean up (delete the list)
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe.serial("Shopping mode", () => {
+  const listName = `Shopping Mode Test ${Date.now()}`;
+
+  test("creates a list with items for testing", async ({ page }) => {
+    await page.goto("/");
+
+    // Create a list
+    await page.getByPlaceholder("New list name...").fill(listName);
+    await page.getByRole("button", { name: "Add" }).click();
+    await expect(page.getByText(listName)).toBeVisible();
+
+    // Navigate to the list detail page
+    await page.getByRole("link", { name: listName }).click();
+    await expect(page).toHaveURL(/\/lists\/[a-f0-9-]+/);
+
+    // Add 3 items
+    await page.getByPlaceholder("Item name...").fill("Milk");
+    await page.getByRole("button", { name: "Add item" }).click();
+    await expect(page.getByText("Milk")).toBeVisible();
+
+    await page.getByPlaceholder("Item name...").fill("Bread");
+    await page.getByRole("button", { name: "Add item" }).click();
+    await expect(page.getByText("Bread")).toBeVisible();
+
+    await page.getByPlaceholder("Item name...").fill("Apples");
+    await page.getByRole("button", { name: "Add item" }).click();
+    await expect(page.getByText("Apples")).toBeVisible();
+  });
+
+  test("navigates to shopping mode from list detail", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: listName }).click();
+
+    // Click "Start Shopping" button
+    await page.getByRole("link", { name: "Start Shopping" }).click();
+    await expect(page).toHaveURL(/\/lists\/[a-f0-9-]+\/shop/);
+
+    // Should show the list name and progress
+    await expect(
+      page.getByRole("heading", { name: listName })
+    ).toBeVisible();
+    await expect(page.getByText("0 of 3 items")).toBeVisible();
+  });
+
+  test("checks off an item and updates progress", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: listName }).click();
+    await page.getByRole("link", { name: "Start Shopping" }).click();
+
+    // Check off "Milk"
+    await page.getByRole("button", { name: "Check Milk" }).click();
+
+    // Progress should update
+    await expect(page.getByText("1 of 3 items")).toBeVisible();
+
+    // The Done section should appear
+    await expect(page.getByText("Done (1)")).toBeVisible();
+  });
+
+  test("checked state persists on reload", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: listName }).click();
+    await page.getByRole("link", { name: "Start Shopping" }).click();
+
+    // Milk should still be checked from the previous test
+    await expect(page.getByText("1 of 3 items")).toBeVisible();
+    await expect(page.getByText("Done (1)")).toBeVisible();
+
+    // The "Uncheck Milk" button should exist (it's in checked state)
+    await expect(
+      page.getByRole("button", { name: "Uncheck Milk" })
+    ).toBeVisible();
+  });
+
+  test("checks all items and shows all done", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: listName }).click();
+    await page.getByRole("link", { name: "Start Shopping" }).click();
+
+    // Milk is already checked, check the other two
+    await page.getByRole("button", { name: "Check Bread" }).click();
+    await page.getByRole("button", { name: "Check Apples" }).click();
+
+    // Should show "All done!"
+    await expect(page.getByText("All done!")).toBeVisible();
+    await expect(page.getByText("Done (3)")).toBeVisible();
+  });
+
+  test("unchecks all items to reset progress", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: listName }).click();
+    await page.getByRole("link", { name: "Start Shopping" }).click();
+
+    // Accept the confirmation dialog
+    page.on("dialog", (dialog) => dialog.accept());
+
+    // Click "Uncheck all"
+    await page.getByRole("button", { name: "Uncheck all" }).click();
+
+    // Progress should reset
+    await expect(page.getByText("0 of 3 items")).toBeVisible();
+
+    // "Uncheck all" button should disappear (no checked items)
+    await expect(
+      page.getByRole("button", { name: "Uncheck all" })
+    ).not.toBeVisible();
+  });
+
+  test("cleans up by deleting the test list", async ({ page }) => {
+    await page.goto("/");
+
+    // Accept the confirmation dialog for delete
+    page.on("dialog", (dialog) => dialog.accept());
+
+    // Find the list card and click Edit, then Delete
+    const listCard = page.locator("div").filter({ hasText: listName }).first();
+    await listCard.getByRole("button", { name: "Edit" }).click();
+    await listCard.getByRole("button", { name: "Delete" }).click();
+
+    // List should be gone
+    await expect(page.getByText(listName)).not.toBeVisible();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -84,6 +84,7 @@ export default defineConfig({
         "stores.spec.ts",
         "item-prices.spec.ts",
         "products.spec.ts",
+        "shopping-mode.spec.ts",
       ],
       use: {
         ...devices["Desktop Chrome"],

--- a/src/app/(protected)/actions.ts
+++ b/src/app/(protected)/actions.ts
@@ -354,6 +354,81 @@ export async function deleteItem(
   return { error: null };
 }
 
+// ─── Shopping Mode Actions ────────────────────────────────────────
+
+/**
+ * Toggle the checked state of a list item (for shopping mode).
+ *
+ * Unlike other actions, this one takes direct parameters instead of
+ * FormData. This is because checking items off needs to feel instant —
+ * it's called from an onClick handler with useOptimistic, not a form.
+ *
+ * Both patterns are valid Server Actions — the "use server" directive
+ * at the top of this file covers all exported functions.
+ */
+export async function toggleItemChecked(
+  itemId: string,
+  listId: string,
+  checked: boolean
+): Promise<ActionResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  // RLS ensures users can only update items in their own lists
+  const { error } = await supabase
+    .from("list_items")
+    .update({ checked })
+    .eq("id", itemId);
+
+  if (error) {
+    return { error: "Could not update item. Please try again." };
+  }
+
+  // Revalidate so the server state matches the optimistic UI.
+  // Without this, useOptimistic reverts to the stale server state
+  // once the transition completes, causing the item to uncheck itself.
+  revalidatePath(`/lists/${listId}/shop`);
+  return { error: null };
+}
+
+/**
+ * Uncheck all items in a shopping list (reset for next shopping trip).
+ *
+ * Sets every item's checked column back to false. Called when the user
+ * taps "Uncheck all" in shopping mode.
+ */
+export async function uncheckAllItems(
+  listId: string
+): Promise<ActionResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  // Update all items in this list — RLS ensures ownership
+  const { error } = await supabase
+    .from("list_items")
+    .update({ checked: false })
+    .eq("list_id", listId);
+
+  if (error) {
+    return { error: "Could not reset items. Please try again." };
+  }
+
+  revalidatePath(`/lists/${listId}/shop`);
+  return { error: null };
+}
+
 // ─── Category Actions ─────────────────────────────────────────────
 
 /**

--- a/src/app/(protected)/lists/[id]/page.tsx
+++ b/src/app/(protected)/lists/[id]/page.tsx
@@ -17,7 +17,7 @@ import {
   updateDiscount,
   deleteDiscount,
 } from "@/app/(protected)/actions";
-import type { ListItemWithCategory } from "@/lib/types";
+import { groupItemsByCategory } from "@/lib/list-helpers";
 
 /**
  * List detail page — shows a shopping list's items with the ability
@@ -48,23 +48,8 @@ export default async function ListDetailPage({
   const { list, items, categories, stores, pricesByProduct, allDiscounts } =
     data;
 
-  // Group items by category name so we can render them in sections.
-  // Items without a category go into "Uncategorized".
-  const grouped = new Map<string, ListItemWithCategory[]>();
-  for (const item of items) {
-    const categoryName = item.categories?.name ?? "Uncategorized";
-    if (!grouped.has(categoryName)) {
-      grouped.set(categoryName, []);
-    }
-    grouped.get(categoryName)!.push(item);
-  }
-
-  // Sort the groups alphabetically, but put "Uncategorized" last
-  const sortedGroups = [...grouped.entries()].sort(([a], [b]) => {
-    if (a === "Uncategorized") return 1;
-    if (b === "Uncategorized") return -1;
-    return a.localeCompare(b);
-  });
+  // Group items by category name so we can render them in sections
+  const sortedGroups = groupItemsByCategory(items);
 
   return (
     <div>
@@ -78,15 +63,27 @@ export default async function ListDetailPage({
       <div className="mt-3 flex items-center justify-between">
         <h2 className="text-xl font-semibold">{list.name}</h2>
 
-        {/* Show "Compare Prices" link only when there are prices to compare */}
-        {pricesByProduct.size > 0 && (
-          <Link
-            href={`/lists/${id}/compare`}
-            className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-800"
-          >
-            Compare Prices
-          </Link>
-        )}
+        <div className="flex items-center gap-2">
+          {/* Show "Start Shopping" when the list has items */}
+          {items.length > 0 && (
+            <Link
+              href={`/lists/${id}/shop`}
+              className="rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700"
+            >
+              Start Shopping
+            </Link>
+          )}
+
+          {/* Show "Compare Prices" link only when there are prices to compare */}
+          {pricesByProduct.size > 0 && (
+            <Link
+              href={`/lists/${id}/compare`}
+              className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-800"
+            >
+              Compare Prices
+            </Link>
+          )}
+        </div>
       </div>
 
       {/* Form to add new items — always visible at the top */}

--- a/src/app/(protected)/lists/[id]/shop/page.tsx
+++ b/src/app/(protected)/lists/[id]/shop/page.tsx
@@ -1,0 +1,100 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { fetchListPageData } from "@/lib/list-data";
+import { calculateStoreTotals, calculateSmartSplit } from "@/lib/comparison";
+import { ShoppingList } from "@/components/ShoppingList";
+import type { BestDealInfo } from "@/lib/types";
+import { toggleItemChecked, uncheckAllItems } from "@/app/(protected)/actions";
+
+/**
+ * Shopping mode page — a streamlined view for checking off items
+ * while shopping in a store.
+ *
+ * This is a Server Component that fetches data and passes it to the
+ * ShoppingList Client Component (which handles the interactive parts
+ * like checking items off with instant feedback).
+ *
+ * It reuses the same data fetching as the list detail and compare pages,
+ * plus the smart split calculation to show the best price per item.
+ */
+export default async function ShopPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  // Reuse the shared data fetching helper
+  const data = await fetchListPageData(id);
+
+  if (!data) {
+    notFound();
+  }
+
+  const { list, items, pricesByProduct, allDiscounts } = data;
+
+  // Calculate the smart split to get best-deal info for each item.
+  // This tells us the cheapest store and price for every item.
+  const storeTotals = calculateStoreTotals(
+    items,
+    pricesByProduct,
+    allDiscounts
+  );
+  const smartSplit = calculateSmartSplit(
+    items,
+    pricesByProduct,
+    allDiscounts,
+    storeTotals
+  );
+
+  // Build a lookup object: item name → best deal info.
+  // We use a plain object (not a Map) because Maps can't be passed
+  // from Server Components to Client Components — they're not serializable.
+  const bestDeals: Record<string, BestDealInfo> = {};
+  for (const group of smartSplit.storeGroups) {
+    for (const splitItem of group.items) {
+      bestDeals[splitItem.itemName] = {
+        storeName: splitItem.storeName,
+        unitPrice: splitItem.unitPrice,
+        lineTotal: splitItem.lineTotal,
+      };
+    }
+  }
+
+  return (
+    <div>
+      <Link
+        href={`/lists/${id}`}
+        className="text-sm text-zinc-500 hover:text-zinc-700"
+      >
+        &larr; Back to list
+      </Link>
+
+      <h2 className="mt-3 text-xl font-semibold">{list.name}</h2>
+
+      {items.length === 0 ? (
+        <div className="mt-8 text-center">
+          <p className="text-sm text-zinc-500">
+            No items in this list yet.
+          </p>
+          <Link
+            href={`/lists/${id}`}
+            className="mt-2 inline-block text-sm text-zinc-700 underline hover:text-zinc-900"
+          >
+            Add items from the list page
+          </Link>
+        </div>
+      ) : (
+        <div className="mt-4">
+          <ShoppingList
+            listId={id}
+            items={items}
+            bestDeals={bestDeals}
+            toggleAction={toggleItemChecked}
+            uncheckAllAction={uncheckAllItems}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,12 +12,7 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
+/* Dark mode disabled — the UI is designed for light mode only */
 
 body {
   background: var(--background);

--- a/src/components/ListItemCard.test.tsx
+++ b/src/components/ListItemCard.test.tsx
@@ -37,6 +37,7 @@ const mockItem: ListItemWithCategory = {
   quantity: 2,
   unit: "L",
   category_id: "cat-1",
+  checked: false,
   categories: { name: "Beverages" },
 };
 
@@ -48,6 +49,7 @@ const mockItemNoCategory: ListItemWithCategory = {
   quantity: 1,
   unit: null,
   category_id: null,
+  checked: false,
   categories: null,
 };
 

--- a/src/components/ListItemCard.tsx
+++ b/src/components/ListItemCard.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useActionState } from "react";
 import { SubmitButton } from "@/components/SubmitButton";
+import { formatQuantity } from "@/lib/list-helpers";
 import type { ListItemWithCategory, Category } from "@/lib/types";
 import type { ActionResult } from "@/app/(protected)/actions";
 
@@ -49,10 +50,7 @@ export function ListItemCard({
     error: null,
   });
 
-  // Format quantity + unit for display (e.g. "2 kg" or just "2")
-  const quantityDisplay = item.unit
-    ? `${item.quantity} ${item.unit}`
-    : `${item.quantity}`;
+  const quantityDisplay = formatQuantity(item.quantity, item.unit);
 
   const error = updateState.error || deleteState.error;
 

--- a/src/components/ShoppingItemCard.test.tsx
+++ b/src/components/ShoppingItemCard.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ShoppingItemCard } from "./ShoppingItemCard";
+import type { ListItemWithCategory } from "@/lib/types";
+import type { BestDealInfo } from "@/lib/types";
+
+const mockItem: ListItemWithCategory = {
+  id: "item-1",
+  list_id: "list-1",
+  product_id: "product-1",
+  name: "Milk",
+  quantity: 2,
+  unit: "L",
+  category_id: "cat-1",
+  checked: false,
+  categories: { name: "Beverages" },
+};
+
+const mockBestDeal: BestDealInfo = {
+  storeName: "Lidl",
+  unitPrice: 0.89,
+  lineTotal: 1.78,
+};
+
+describe("ShoppingItemCard", () => {
+  it("renders item name and quantity with unit", () => {
+    render(
+      <ShoppingItemCard
+        item={mockItem}
+        checked={false}
+        bestDeal={null}
+        showPrices={false}
+        onToggle={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+    expect(screen.getByText("2 L")).toBeInTheDocument();
+  });
+
+  it("renders quantity without unit when unit is null", () => {
+    const itemNoUnit = { ...mockItem, unit: null };
+    render(
+      <ShoppingItemCard
+        item={itemNoUnit}
+        checked={false}
+        bestDeal={null}
+        showPrices={false}
+        onToggle={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("shows best deal info when showPrices is true", () => {
+    render(
+      <ShoppingItemCard
+        item={mockItem}
+        checked={false}
+        bestDeal={mockBestDeal}
+        showPrices={true}
+        onToggle={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("@ Lidl")).toBeInTheDocument();
+  });
+
+  it("hides price info when showPrices is false", () => {
+    render(
+      <ShoppingItemCard
+        item={mockItem}
+        checked={false}
+        bestDeal={mockBestDeal}
+        showPrices={false}
+        onToggle={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByText("@ Lidl")).not.toBeInTheDocument();
+  });
+
+  it("does not show price when bestDeal is null", () => {
+    render(
+      <ShoppingItemCard
+        item={mockItem}
+        checked={false}
+        bestDeal={null}
+        showPrices={true}
+        onToggle={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByText("@ Lidl")).not.toBeInTheDocument();
+  });
+
+  it("calls onToggle with correct arguments when clicked", () => {
+    const mockOnToggle = jest.fn();
+    render(
+      <ShoppingItemCard
+        item={mockItem}
+        checked={false}
+        bestDeal={null}
+        showPrices={false}
+        onToggle={mockOnToggle}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Check Milk" }));
+    expect(mockOnToggle).toHaveBeenCalledWith("item-1", true);
+  });
+
+  it("calls onToggle to uncheck when already checked", () => {
+    const mockOnToggle = jest.fn();
+    render(
+      <ShoppingItemCard
+        item={mockItem}
+        checked={true}
+        bestDeal={null}
+        showPrices={false}
+        onToggle={mockOnToggle}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Uncheck Milk" }));
+    expect(mockOnToggle).toHaveBeenCalledWith("item-1", false);
+  });
+
+  it("renders checked visual state with strikethrough", () => {
+    render(
+      <ShoppingItemCard
+        item={mockItem}
+        checked={true}
+        bestDeal={null}
+        showPrices={false}
+        onToggle={jest.fn()}
+      />
+    );
+
+    const nameElement = screen.getByText("Milk");
+    expect(nameElement).toHaveClass("line-through");
+  });
+
+  it("renders unchecked visual state without strikethrough", () => {
+    render(
+      <ShoppingItemCard
+        item={mockItem}
+        checked={false}
+        bestDeal={null}
+        showPrices={false}
+        onToggle={jest.fn()}
+      />
+    );
+
+    const nameElement = screen.getByText("Milk");
+    expect(nameElement).not.toHaveClass("line-through");
+  });
+});

--- a/src/components/ShoppingItemCard.tsx
+++ b/src/components/ShoppingItemCard.tsx
@@ -1,0 +1,94 @@
+/**
+ * A single item row in shopping mode.
+ *
+ * Unlike ListItemCard (used for editing), this component is focused on
+ * the shopping experience: a large tappable area to check/uncheck items.
+ * No edit or delete buttons — just a checkbox, item name, quantity, and
+ * optionally the best price and store name.
+ *
+ * The entire row is tappable (not just a small checkbox) so it's easy
+ * to use on a phone with one hand. The minimum height is 44px to meet
+ * touch target guidelines.
+ */
+"use client";
+
+import type { ListItemWithCategory, BestDealInfo } from "@/lib/types";
+import { formatQuantity } from "@/lib/list-helpers";
+
+export function ShoppingItemCard({
+  item,
+  checked,
+  bestDeal,
+  showPrices,
+  onToggle,
+}: {
+  /** The item to display */
+  item: ListItemWithCategory;
+  /** Whether the item is currently checked (from optimistic state) */
+  checked: boolean;
+  /** Best deal info from smart split (null if no prices) */
+  bestDeal: BestDealInfo | null;
+  /** Whether to show price info */
+  showPrices: boolean;
+  /** Called when the user taps the row */
+  onToggle: (itemId: string, newChecked: boolean) => void;
+}) {
+  const quantityDisplay = formatQuantity(item.quantity, item.unit);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onToggle(item.id, !checked)}
+      className={`flex w-full min-h-[44px] items-center gap-3 rounded-md border px-3 py-2 text-left transition-colors active:bg-zinc-100 ${
+        checked
+          ? "border-zinc-100 bg-zinc-50 opacity-60"
+          : "border-zinc-200 bg-white"
+      }`}
+      aria-label={`${checked ? "Uncheck" : "Check"} ${item.name}`}
+    >
+      {/* Checkbox indicator */}
+      <div
+        className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 transition-colors ${
+          checked
+            ? "border-green-500 bg-green-500 text-white"
+            : "border-zinc-300"
+        }`}
+      >
+        {checked && (
+          // Simple checkmark using CSS — no icon library needed
+          <svg
+            className="h-3.5 w-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={3}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        )}
+      </div>
+
+      {/* Item name and quantity */}
+      <div className="min-w-0 flex-1">
+        <p
+          className={`text-sm font-medium ${
+            checked ? "text-zinc-400 line-through" : "text-zinc-900"
+          }`}
+        >
+          {item.name}
+        </p>
+        <p className="text-xs text-zinc-400">{quantityDisplay}</p>
+      </div>
+
+      {/* Best price and store (optional) */}
+      {showPrices && bestDeal && (
+        <div className="shrink-0 text-right">
+          <p className={`text-sm ${checked ? "text-zinc-400" : "text-zinc-600"}`}>
+            &euro;{bestDeal.lineTotal.toFixed(2)}
+          </p>
+          <p className="text-xs text-zinc-400">@ {bestDeal.storeName}</p>
+        </div>
+      )}
+    </button>
+  );
+}

--- a/src/components/ShoppingList.test.tsx
+++ b/src/components/ShoppingList.test.tsx
@@ -1,0 +1,219 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ShoppingList } from "./ShoppingList";
+import type { ListItemWithCategory } from "@/lib/types";
+import type { BestDealInfo } from "@/lib/types";
+
+// Mock window.confirm
+const mockConfirm = jest.fn();
+window.confirm = mockConfirm;
+
+const mockItems: ListItemWithCategory[] = [
+  {
+    id: "item-1",
+    list_id: "list-1",
+    product_id: "product-1",
+    name: "Milk",
+    quantity: 2,
+    unit: "L",
+    category_id: "cat-1",
+    checked: false,
+    categories: { name: "Beverages" },
+  },
+  {
+    id: "item-2",
+    list_id: "list-1",
+    product_id: "product-2",
+    name: "Apples",
+    quantity: 1,
+    unit: "kg",
+    category_id: "cat-2",
+    checked: false,
+    categories: { name: "Fruits" },
+  },
+  {
+    id: "item-3",
+    list_id: "list-1",
+    product_id: "product-3",
+    name: "Bread",
+    quantity: 1,
+    unit: null,
+    category_id: null,
+    checked: true,
+    categories: null,
+  },
+];
+
+const mockBestDeals: Record<string, BestDealInfo> = {
+  Milk: { storeName: "Lidl", unitPrice: 0.89, lineTotal: 1.78 },
+  Apples: { storeName: "Continente", unitPrice: 1.89, lineTotal: 1.89 },
+};
+
+const mockToggleAction = jest.fn().mockResolvedValue({ error: null });
+const mockUncheckAllAction = jest.fn().mockResolvedValue({ error: null });
+
+describe("ShoppingList", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders progress bar with correct counts", () => {
+    render(
+      <ShoppingList
+        listId="list-1"
+        items={mockItems}
+        bestDeals={mockBestDeals}
+        toggleAction={mockToggleAction}
+        uncheckAllAction={mockUncheckAllAction}
+      />
+    );
+
+    // 1 of 3 items checked (Bread is checked)
+    expect(screen.getByText("1 of 3 items")).toBeInTheDocument();
+  });
+
+  it("groups unchecked items by category", () => {
+    render(
+      <ShoppingList
+        listId="list-1"
+        items={mockItems}
+        bestDeals={mockBestDeals}
+        toggleAction={mockToggleAction}
+        uncheckAllAction={mockUncheckAllAction}
+      />
+    );
+
+    // Category headers for unchecked items
+    expect(screen.getByText("Beverages")).toBeInTheDocument();
+    expect(screen.getByText("Fruits")).toBeInTheDocument();
+  });
+
+  it("shows checked items in a Done section", () => {
+    render(
+      <ShoppingList
+        listId="list-1"
+        items={mockItems}
+        bestDeals={mockBestDeals}
+        toggleAction={mockToggleAction}
+        uncheckAllAction={mockUncheckAllAction}
+      />
+    );
+
+    // Done section header
+    expect(screen.getByText("Done (1)")).toBeInTheDocument();
+    // Bread is the checked item
+    expect(screen.getByText("Bread")).toBeInTheDocument();
+  });
+
+  it("shows Uncheck all button when there are checked items", () => {
+    render(
+      <ShoppingList
+        listId="list-1"
+        items={mockItems}
+        bestDeals={mockBestDeals}
+        toggleAction={mockToggleAction}
+        uncheckAllAction={mockUncheckAllAction}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Uncheck all" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not show Uncheck all when no items are checked", () => {
+    const allUnchecked = mockItems.map((item) => ({
+      ...item,
+      checked: false,
+    }));
+
+    render(
+      <ShoppingList
+        listId="list-1"
+        items={allUnchecked}
+        bestDeals={mockBestDeals}
+        toggleAction={mockToggleAction}
+        uncheckAllAction={mockUncheckAllAction}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Uncheck all" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows confirm dialog when Uncheck all is clicked", () => {
+    mockConfirm.mockReturnValue(false);
+
+    render(
+      <ShoppingList
+        listId="list-1"
+        items={mockItems}
+        bestDeals={mockBestDeals}
+        toggleAction={mockToggleAction}
+        uncheckAllAction={mockUncheckAllAction}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Uncheck all" }));
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      "Uncheck all items? This will reset your shopping progress."
+    );
+  });
+
+  it("shows price toggle when there are best deals", () => {
+    render(
+      <ShoppingList
+        listId="list-1"
+        items={mockItems}
+        bestDeals={mockBestDeals}
+        toggleAction={mockToggleAction}
+        uncheckAllAction={mockUncheckAllAction}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Hide prices" })
+    ).toBeInTheDocument();
+  });
+
+  it("hides price toggle when there are no best deals", () => {
+    render(
+      <ShoppingList
+        listId="list-1"
+        items={mockItems}
+        bestDeals={{}}
+        toggleAction={mockToggleAction}
+        uncheckAllAction={mockUncheckAllAction}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Hide prices" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Show prices" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("toggles price visibility when toggle button is clicked", () => {
+    render(
+      <ShoppingList
+        listId="list-1"
+        items={mockItems}
+        bestDeals={mockBestDeals}
+        toggleAction={mockToggleAction}
+        uncheckAllAction={mockUncheckAllAction}
+      />
+    );
+
+    // Initially prices are shown
+    const toggleButton = screen.getByRole("button", { name: "Hide prices" });
+    fireEvent.click(toggleButton);
+
+    // Now it should say "Show prices"
+    expect(
+      screen.getByRole("button", { name: "Show prices" })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ShoppingList.tsx
+++ b/src/components/ShoppingList.tsx
@@ -1,0 +1,178 @@
+/**
+ * Main shopping mode component.
+ *
+ * This Client Component manages the interactive shopping experience:
+ * - Uses useOptimistic for instant check/uncheck feedback
+ * - Groups items by category with unchecked items first
+ * - Shows a "Done" section at the bottom for checked items
+ * - Toggle to show/hide prices
+ * - "Uncheck all" button to reset for the next shopping trip
+ *
+ * Why useOptimistic? It's a React 19 hook that shows the new value
+ * immediately while the Server Action runs in the background. If the
+ * action fails, React automatically reverts to the server state.
+ * This makes checking items feel instant — no loading spinner needed.
+ */
+"use client";
+
+import { useOptimistic, useTransition, useState } from "react";
+import { ShoppingProgressBar } from "@/components/ShoppingProgressBar";
+import { ShoppingItemCard } from "@/components/ShoppingItemCard";
+import { groupItemsByCategory } from "@/lib/list-helpers";
+import type { BestDealInfo } from "@/lib/types";
+import type { ListItemWithCategory } from "@/lib/types";
+
+export function ShoppingList({
+  listId,
+  items,
+  bestDeals,
+  toggleAction,
+  uncheckAllAction,
+}: {
+  /** The shopping list ID */
+  listId: string;
+  /** All items in the list (from the server) */
+  items: ListItemWithCategory[];
+  /** Best deal info per item name (from smart split calculation) */
+  bestDeals: Record<string, BestDealInfo>;
+  /** Server Action to toggle an item's checked state */
+  toggleAction: (
+    itemId: string,
+    listId: string,
+    checked: boolean
+  ) => Promise<{ error: string | null }>;
+  /** Server Action to uncheck all items */
+  uncheckAllAction: (listId: string) => Promise<{ error: string | null }>;
+}) {
+  const [showPrices, setShowPrices] = useState(true);
+  const [, startTransition] = useTransition();
+
+  // useOptimistic gives us a way to show the checked state immediately
+  // while the server action runs in the background. The first argument
+  // is the current server state, and the second is a function that
+  // computes the optimistic state from the current state + the action.
+  // We pass an explicit { itemId, checked } object (not just the ID)
+  // so that rapid double-taps don't cause a toggle-race — both the
+  // optimistic UI and the server action use the same target value.
+  const [optimisticItems, setOptimisticItem] = useOptimistic(
+    items,
+    (
+      currentItems: ListItemWithCategory[],
+      update: { itemId: string; checked: boolean }
+    ) =>
+      currentItems.map((item) =>
+        item.id === update.itemId
+          ? { ...item, checked: update.checked }
+          : item
+      )
+  );
+
+  function handleToggle(itemId: string, newChecked: boolean) {
+    // Show the change immediately (optimistic update)
+    startTransition(() => {
+      setOptimisticItem({ itemId, checked: newChecked });
+      // Call the server action in the background
+      toggleAction(itemId, listId, newChecked);
+    });
+  }
+
+  function handleUncheckAll() {
+    const confirmed = window.confirm(
+      "Uncheck all items? This will reset your shopping progress."
+    );
+    if (!confirmed) return;
+
+    startTransition(() => {
+      uncheckAllAction(listId);
+    });
+  }
+
+  // Split items into unchecked (remaining) and checked (done)
+  const remainingItems = optimisticItems.filter((item) => !item.checked);
+  const doneItems = optimisticItems.filter((item) => item.checked);
+
+  // Group remaining items by category
+  const sortedGroups = groupItemsByCategory(remainingItems);
+  const hasPrices = Object.keys(bestDeals).length > 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Progress bar */}
+      <ShoppingProgressBar
+        checkedCount={doneItems.length}
+        totalCount={optimisticItems.length}
+      />
+
+      {/* Price toggle — only shown if there are prices to display */}
+      {hasPrices && (
+        <button
+          type="button"
+          onClick={() => setShowPrices(!showPrices)}
+          className="self-end rounded-md border border-zinc-200 px-2.5 py-1 text-xs text-zinc-500 hover:bg-zinc-100"
+        >
+          {showPrices ? "Hide prices" : "Show prices"}
+        </button>
+      )}
+
+      {/* Remaining items grouped by category */}
+      {sortedGroups.length > 0 && (
+        <div className="flex flex-col gap-4">
+          {sortedGroups.map(([categoryName, groupItems]) => (
+            <div key={categoryName}>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-400">
+                {categoryName}
+              </p>
+              <div className="flex flex-col gap-1.5">
+                {groupItems.map((item) => (
+                  <ShoppingItemCard
+                    key={item.id}
+                    item={item}
+                    checked={false}
+                    bestDeal={bestDeals[item.name] ?? null}
+                    showPrices={showPrices}
+                    onToggle={handleToggle}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Done section — checked items at the bottom */}
+      {doneItems.length > 0 && (
+        <div>
+          {remainingItems.length > 0 && (
+            <hr className="mb-4 border-zinc-200" />
+          )}
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-green-600">
+            Done ({doneItems.length})
+          </p>
+          <div className="flex flex-col gap-1.5">
+            {doneItems.map((item) => (
+              <ShoppingItemCard
+                key={item.id}
+                item={item}
+                checked={true}
+                bestDeal={bestDeals[item.name] ?? null}
+                showPrices={showPrices}
+                onToggle={handleToggle}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Uncheck all button — only shown if there are checked items */}
+      {doneItems.length > 0 && (
+        <button
+          type="button"
+          onClick={handleUncheckAll}
+          className="mt-2 self-center rounded-md border border-zinc-300 px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-100"
+        >
+          Uncheck all
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ShoppingProgressBar.test.tsx
+++ b/src/components/ShoppingProgressBar.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { ShoppingProgressBar } from "./ShoppingProgressBar";
+
+describe("ShoppingProgressBar", () => {
+  it("renders the item count", () => {
+    render(<ShoppingProgressBar checkedCount={3} totalCount={8} />);
+    expect(screen.getByText("3 of 8 items")).toBeInTheDocument();
+  });
+
+  it("shows 'All done!' when all items are checked", () => {
+    render(<ShoppingProgressBar checkedCount={5} totalCount={5} />);
+    expect(screen.getByText("All done!")).toBeInTheDocument();
+  });
+
+  it("renders progress bar with correct width", () => {
+    const { container } = render(
+      <ShoppingProgressBar checkedCount={2} totalCount={4} />
+    );
+
+    // The inner bar should have 50% width
+    const innerBar = container.querySelector("[style]");
+    expect(innerBar).toHaveStyle({ width: "50%" });
+  });
+
+  it("renders 0% width when no items are checked", () => {
+    const { container } = render(
+      <ShoppingProgressBar checkedCount={0} totalCount={3} />
+    );
+
+    const innerBar = container.querySelector("[style]");
+    expect(innerBar).toHaveStyle({ width: "0%" });
+  });
+
+  it("handles empty list (0 total items)", () => {
+    render(<ShoppingProgressBar checkedCount={0} totalCount={0} />);
+    expect(screen.getByText("0 of 0 items")).toBeInTheDocument();
+  });
+});

--- a/src/components/ShoppingProgressBar.tsx
+++ b/src/components/ShoppingProgressBar.tsx
@@ -1,0 +1,34 @@
+/**
+ * Progress bar for shopping mode.
+ *
+ * Shows how many items have been checked off (e.g., "3 of 8 items")
+ * with a visual bar that fills up as items are checked. When all items
+ * are done, the text changes to "All done!" with a green color.
+ */
+
+export function ShoppingProgressBar({
+  checkedCount,
+  totalCount,
+}: {
+  /** How many items have been checked off */
+  checkedCount: number;
+  /** Total number of items in the list */
+  totalCount: number;
+}) {
+  const allDone = totalCount > 0 && checkedCount === totalCount;
+  const percentage = totalCount > 0 ? (checkedCount / totalCount) * 100 : 0;
+
+  return (
+    <div>
+      <p className={`text-sm font-medium ${allDone ? "text-green-600" : "text-zinc-600"}`}>
+        {allDone ? "All done!" : `${checkedCount} of ${totalCount} items`}
+      </p>
+      <div className="mt-1 h-2 rounded-full bg-zinc-200">
+        <div
+          className={`h-2 rounded-full transition-all ${allDone ? "bg-green-500" : "bg-zinc-900"}`}
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/comparison.test.ts
+++ b/src/lib/comparison.test.ts
@@ -15,6 +15,7 @@ function makeItem(overrides: Partial<ListItem> = {}): ListItem {
     quantity: 1,
     unit: null,
     category_id: null,
+    checked: false,
     ...overrides,
   };
 }

--- a/src/lib/list-helpers.ts
+++ b/src/lib/list-helpers.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared helper functions for working with list items.
+ *
+ * These are small utilities used by multiple components and pages.
+ * Extracting them here avoids duplicating the same logic in multiple
+ * files (DRY principle).
+ */
+
+import type { ListItemWithCategory } from "@/lib/types";
+
+/**
+ * Group items by their category name, sorted alphabetically.
+ *
+ * Items without a category are grouped under "Uncategorized", which
+ * always appears last. This is the same grouping logic used on the
+ * list detail page and in shopping mode.
+ *
+ * @returns An array of [categoryName, items[]] tuples, sorted by name
+ */
+export function groupItemsByCategory(
+  items: ListItemWithCategory[]
+): [string, ListItemWithCategory[]][] {
+  const grouped = new Map<string, ListItemWithCategory[]>();
+
+  for (const item of items) {
+    const categoryName = item.categories?.name ?? "Uncategorized";
+    if (!grouped.has(categoryName)) {
+      grouped.set(categoryName, []);
+    }
+    grouped.get(categoryName)!.push(item);
+  }
+
+  // Sort alphabetically, but put "Uncategorized" last
+  return [...grouped.entries()].sort(([a], [b]) => {
+    if (a === "Uncategorized") return 1;
+    if (b === "Uncategorized") return -1;
+    return a.localeCompare(b);
+  });
+}
+
+/**
+ * Format a quantity and optional unit for display.
+ *
+ * Examples: "2 kg", "1 L", "3" (when no unit)
+ */
+export function formatQuantity(
+  quantity: number,
+  unit: string | null
+): string {
+  return unit ? `${quantity} ${unit}` : `${quantity}`;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,6 +38,7 @@ export type ListItem = {
   quantity: number;
   unit: string | null;
   category_id: string | null;
+  checked: boolean; // Phase 7: whether the item has been checked off while shopping
 };
 
 /**
@@ -96,4 +97,11 @@ export type Discount = {
   type: "percentage" | "fixed";
   value: number;
   description: string | null;
+};
+
+/** Best deal info for an item from the smart split calculation */
+export type BestDealInfo = {
+  storeName: string;
+  unitPrice: number;
+  lineTotal: number;
 };

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -125,7 +125,8 @@ create table list_items (
   name text not null,
   quantity numeric default 1 not null,
   unit text,
-  category_id uuid references categories(id) on delete set null
+  category_id uuid references categories(id) on delete set null,
+  checked boolean default false not null  -- Phase 7: shopping mode check-off
 );
 
 alter table list_items enable row level security;


### PR DESCRIPTION
## What
Add shopping mode — a streamlined check-off view for shopping lists (Phase 7).

## Why
Users need a mobile-friendly way to check off items while shopping in a store, separate from the list editing view.

## Changes
- Add `checked` boolean column to `list_items` table schema
- Add `BestDealInfo` type and `checked` field to `ListItem` type
- Add `toggleItemChecked` and `uncheckAllItems` server actions with optimistic UI support
- Create `ShoppingProgressBar` component (progress bar with "X of Y items" / "All done!")
- Create `ShoppingItemCard` component (tappable row with checkbox, item info, optional best price)
- Create `ShoppingList` component (client component with `useOptimistic`, category grouping, done section, price toggle)
- Create `/lists/[id]/shop` page (server component reusing `fetchListPageData` and smart split calculations)
- Add "Start Shopping" button (green) to list detail page
- Extract shared `groupItemsByCategory()` and `formatQuantity()` helpers to `src/lib/list-helpers.ts`
- Disable dark mode CSS override (was causing low contrast text on light backgrounds)
- Add Phases 8-10 to CLAUDE.md (shared lists, template lists, final polish)
- Add E2E test for shopping mode flow
- Add unit tests for all new components
- Update existing test mocks with `checked` field

## Testing
- `npm run build` — passes
- `npm test` — 126 tests pass
- `npm run test:e2e` — run `shopping-mode.spec.ts` for the full flow
- Manual: navigate to a list → click "Start Shopping" → check/uncheck items → verify persistence on reload → test "Uncheck all" → toggle price visibility

## Checklist
- [x] Build passes
- [x] Unit tests pass (126/126)
- [x] E2E test added
- [x] Visual verification done