### PR TITLE
feat: add shared lists with collaborative editing

### DIFF
--- a/src/app/(protected)/actions.ts
+++ b/src/app/(protected)/actions.ts
@@ -23,6 +23,26 @@ export type ActionResult = {
 };
 
 /**
+ * Get the user_id of the list owner.
+ *
+ * When a shared user adds or updates items in a shared list, we need
+ * to create products in the list OWNER's catalog (not the shared user's).
+ * This keeps prices consistent — all collaborators see the same products
+ * with the same prices.
+ */
+async function getListOwnerId(
+  supabase: SupabaseClient,
+  listId: string
+): Promise<string | null> {
+  const { data } = await supabase
+    .from("shopping_lists")
+    .select("user_id")
+    .eq("id", listId)
+    .single();
+  return data?.user_id ?? null;
+}
+
+/**
  * Find an existing product by name (case-insensitive) or create a new one.
  *
  * Products are shared across lists — if "Milk" already exists as a product,
@@ -215,9 +235,17 @@ export async function addItem(
     return { error: "You must be logged in." };
   }
 
-  // Find or create a product with this name.
+  // Use the list owner's user_id for product lookup.
+  // If this is a shared list, the product needs to be in the owner's catalog
+  // so prices stay consistent for all collaborators.
+  const ownerId = await getListOwnerId(supabase, listId);
+  if (!ownerId) {
+    return { error: "List not found." };
+  }
+
+  // Find or create a product with this name in the owner's catalog.
   // ilike does a case-insensitive match so "Milk" and "milk" are the same product.
-  const productId = await findOrCreateProduct(supabase, user.id, name.trim());
+  const productId = await findOrCreateProduct(supabase, ownerId, name.trim());
   if (!productId) {
     return { error: "Could not create product. Please try again." };
   }
@@ -293,11 +321,17 @@ export async function updateItem(
     return { error: "You must be logged in." };
   }
 
-  // Always find/create a product for the current name.
-  // If the user renamed the item, this links it to the correct product.
-  const productId = await findOrCreateProduct(supabase, user.id, name.trim());
+  // Use the list owner's catalog for consistent product/price data.
+  const ownerId = await getListOwnerId(supabase, listId);
+  if (!ownerId) {
+    return { error: "List not found." };
+  }
 
-  // RLS ensures users can only update items in their own lists
+  // Always find/create a product for the current name in the owner's catalog.
+  // If the user renamed the item, this links it to the correct product.
+  const productId = await findOrCreateProduct(supabase, ownerId, name.trim());
+
+  // RLS ensures users can only update items in their own or shared lists
   const { error } = await supabase
     .from("list_items")
     .update({
@@ -1045,5 +1079,106 @@ export async function deleteDiscount(
   if (listId) {
     revalidatePath(`/lists/${listId}`);
   }
+  return { error: null };
+}
+
+// ─── List Sharing Actions ────────────────────────────────────────
+
+/**
+ * Share a shopping list with another user by email.
+ *
+ * Looks up the recipient's user ID using the get_user_id_by_email
+ * database function, then inserts a row into list_shares.
+ * RLS ensures only the list owner can share.
+ */
+export async function shareList(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const listId = formData.get("list_id") as string;
+  const email = formData.get("email") as string;
+
+  if (!email || !email.includes("@")) {
+    return { error: "Please enter a valid email address." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  // Can't share with yourself
+  if (email.toLowerCase() === user.email?.toLowerCase()) {
+    return { error: "You can't share a list with yourself." };
+  }
+
+  // Look up the recipient's user ID by email.
+  // This calls a SECURITY DEFINER function that can access auth.users.
+  const { data: recipientId, error: lookupError } = await supabase.rpc(
+    "get_user_id_by_email",
+    { lookup_email: email.toLowerCase() }
+  );
+
+  if (lookupError || !recipientId) {
+    return { error: "No user found with that email address." };
+  }
+
+  // Insert the share — RLS ensures only the list owner can do this
+  const { error } = await supabase
+    .from("list_shares")
+    .insert({ list_id: listId, user_id: recipientId });
+
+  if (error) {
+    // Unique constraint violation means already shared
+    if (error.code === "23505") {
+      return { error: "This list is already shared with that user." };
+    }
+    return { error: "Could not share list. Please try again." };
+  }
+
+  revalidatePath(`/lists/${listId}`);
+  return { error: null };
+}
+
+/**
+ * Remove a user's access to a shared shopping list.
+ *
+ * RLS ensures only the list owner can remove shares.
+ */
+export async function unshareList(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const shareId = formData.get("share_id") as string;
+  const listId = formData.get("list_id") as string;
+
+  if (!shareId) {
+    return { error: "Missing share ID." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  // RLS ensures only the list owner can delete shares
+  const { error } = await supabase
+    .from("list_shares")
+    .delete()
+    .eq("id", shareId);
+
+  if (error) {
+    return { error: "Could not remove share. Please try again." };
+  }
+
+  revalidatePath(`/lists/${listId}`);
   return { error: null };
 }

--- a/src/app/(protected)/lists/[id]/page.tsx
+++ b/src/app/(protected)/lists/[id]/page.tsx
@@ -1,10 +1,12 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
 import { fetchListPageData } from "@/lib/list-data";
 import { AddItemForm } from "@/components/AddItemForm";
 import { ListItemCard } from "@/components/ListItemCard";
 import { ItemPricesSection } from "@/components/ItemPricesSection";
 import { EmptyItemState } from "@/components/EmptyItemState";
+import { ShareListSection } from "@/components/ShareListSection";
 import {
   addItem,
   updateItem,
@@ -16,6 +18,8 @@ import {
   addDiscount,
   updateDiscount,
   deleteDiscount,
+  shareList,
+  unshareList,
 } from "@/app/(protected)/actions";
 import { groupItemsByCategory } from "@/lib/list-helpers";
 
@@ -45,8 +49,26 @@ export default async function ListDetailPage({
     notFound();
   }
 
-  const { list, items, categories, stores, pricesByProduct, allDiscounts } =
-    data;
+  const {
+    list,
+    items,
+    categories,
+    stores,
+    pricesByProduct,
+    allDiscounts,
+    isOwner,
+  } = data;
+
+  // Fetch the list of shared users (only returns results for the owner)
+  let shares: { id: string; user_id: string; email: string }[] = [];
+  if (isOwner) {
+    const supabase = await createClient();
+    const { data: sharesData } = await supabase.rpc(
+      "get_list_shares_with_email",
+      { p_list_id: id }
+    );
+    shares = sharesData ?? [];
+  }
 
   // Group items by category name so we can render them in sections
   const sortedGroups = groupItemsByCategory(items);
@@ -85,6 +107,25 @@ export default async function ListDetailPage({
           )}
         </div>
       </div>
+
+      {/* Share management — only visible to the list owner */}
+      {isOwner && (
+        <div className="mt-3">
+          <ShareListSection
+            listId={id}
+            shares={shares}
+            shareAction={shareList}
+            unshareAction={unshareList}
+          />
+        </div>
+      )}
+
+      {/* Badge for shared users so they know who owns the list */}
+      {!isOwner && (
+        <p className="mt-2 text-xs text-zinc-400">
+          Shared with you — you can view and edit items
+        </p>
+      )}
 
       {/* Form to add new items — always visible at the top */}
       <div className="mt-4">

--- a/src/app/(protected)/page.tsx
+++ b/src/app/(protected)/page.tsx
@@ -2,8 +2,9 @@ import { createClient } from "@/lib/supabase/server";
 import { createList, updateList, deleteList } from "./actions";
 import { ShoppingListForm } from "@/components/ShoppingListForm";
 import { ShoppingListCard } from "@/components/ShoppingListCard";
+import { SharedListCard } from "@/components/SharedListCard";
 import { EmptyListState } from "@/components/EmptyListState";
-import type { ShoppingList } from "@/lib/types";
+import type { ShoppingList, SharedList } from "@/lib/types";
 
 /**
  * Home page — shows the user's shopping lists.
@@ -18,18 +19,27 @@ import type { ShoppingList } from "@/lib/types";
 export default async function HomePage() {
   const supabase = await createClient();
 
-  // Fetch all shopping lists for the current user, newest first.
-  // We filter out templates (is_template = false) since those are
-  // a separate feature for a later phase.
-  // RLS ensures we only get the logged-in user's lists.
-  const { data: lists } = await supabase
-    .from("shopping_lists")
-    .select("*")
-    .eq("is_template", false)
-    .order("created_at", { ascending: false });
+  // Fetch the current user (needed to filter owned lists)
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  // Cast to our TypeScript type for proper autocomplete
+  // Fetch owned lists and shared lists in parallel (independent queries).
+  // - Owned lists: filter by user_id explicitly so RLS-visible shared lists
+  //   aren't included (we show those separately with owner email from the RPC).
+  // - Shared lists: uses a database function that joins auth.users for email.
+  const [{ data: lists }, { data: sharedListsData }] = await Promise.all([
+    supabase
+      .from("shopping_lists")
+      .select("*")
+      .eq("user_id", user!.id)
+      .eq("is_template", false)
+      .order("created_at", { ascending: false }),
+    supabase.rpc("get_shared_lists"),
+  ]);
+
   const shoppingLists = (lists ?? []) as ShoppingList[];
+  const sharedLists = (sharedListsData ?? []) as SharedList[];
 
   return (
     <div className="flex flex-col gap-4">
@@ -52,6 +62,18 @@ export default async function HomePage() {
             />
           ))}
         </div>
+      )}
+
+      {/* Lists that other users have shared with the current user */}
+      {sharedLists.length > 0 && (
+        <>
+          <h2 className="mt-6 text-xl font-semibold">Shared with me</h2>
+          <div className="flex flex-col gap-2">
+            {sharedLists.map((list) => (
+              <SharedListCard key={list.id} list={list} />
+            ))}
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/components/ShareListSection.tsx
+++ b/src/components/ShareListSection.tsx
@@ -1,0 +1,136 @@
+/**
+ * Share management section for a shopping list.
+ *
+ * Shown only to the list owner on the list detail page. Lets them:
+ * 1. Share the list with another user by entering their email
+ * 2. See who the list is already shared with
+ * 3. Remove a shared user
+ *
+ * "use client" is needed because we use useState to toggle the section
+ * open/closed and useActionState for the share/unshare Server Actions.
+ */
+"use client";
+
+import { useState, useActionState } from "react";
+import { SubmitButton } from "@/components/SubmitButton";
+import type { ActionResult } from "@/app/(protected)/actions";
+
+/** A shared user record with their email (from the database function) */
+type ShareWithEmail = {
+  id: string;
+  user_id: string;
+  email: string;
+};
+
+export function ShareListSection({
+  listId,
+  shares,
+  shareAction,
+  unshareAction,
+}: {
+  /** The ID of the list being shared */
+  listId: string;
+  /** Current list of shared users (with emails) */
+  shares: ShareWithEmail[];
+  /** Server Action to share the list with a new user */
+  shareAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+  /** Server Action to remove a shared user */
+  unshareAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+}) {
+  // Toggle the share section open/closed
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Track the share form state (for error messages)
+  const [shareState, shareFormAction] = useActionState(shareAction, {
+    error: null,
+  });
+
+  // Track the unshare form state
+  const [unshareState, unshareFormAction] = useActionState(unshareAction, {
+    error: null,
+  });
+
+  const error = shareState.error || unshareState.error;
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={() => setIsOpen(true)}
+        className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm text-zinc-600 hover:bg-zinc-100"
+      >
+        Share
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-zinc-200 bg-white p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold">Share this list</h3>
+        <button
+          onClick={() => setIsOpen(false)}
+          className="text-xs text-zinc-400 hover:text-zinc-600"
+        >
+          Close
+        </button>
+      </div>
+
+      {/* Form to share with a new user by email */}
+      <form action={shareFormAction} className="flex gap-2">
+        <input type="hidden" name="list_id" value={listId} />
+        <input
+          type="email"
+          name="email"
+          placeholder="Enter email address"
+          required
+          className="flex-1 rounded-md border border-zinc-300 px-3 py-1.5 text-sm focus:border-zinc-500 focus:outline-none"
+        />
+        <SubmitButton
+          label="Share"
+          pendingLabel="Sharing..."
+          className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+        />
+      </form>
+
+      {/* Error message */}
+      {error && (
+        <p className="mt-2 rounded-md bg-red-50 p-2 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+
+      {/* List of users the list is shared with */}
+      {shares.length > 0 && (
+        <div className="mt-3 flex flex-col gap-1">
+          <p className="text-xs font-medium text-zinc-400 uppercase tracking-wide">
+            Shared with
+          </p>
+          {shares.map((share) => (
+            <div
+              key={share.id}
+              className="flex items-center justify-between rounded-md bg-zinc-50 px-3 py-2"
+            >
+              <span className="text-sm text-zinc-700">{share.email}</span>
+              <form action={unshareFormAction}>
+                <input type="hidden" name="share_id" value={share.id} />
+                <input type="hidden" name="list_id" value={listId} />
+                <button
+                  type="submit"
+                  className="text-xs text-red-600 hover:text-red-800"
+                >
+                  Remove
+                </button>
+              </form>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SharedListCard.tsx
+++ b/src/components/SharedListCard.tsx
@@ -1,0 +1,26 @@
+/**
+ * A card that displays a shopping list shared with the current user.
+ *
+ * Unlike ShoppingListCard, this is read-only — shared users can't
+ * rename or delete the list (only the owner can). It shows who
+ * shared the list with you.
+ */
+
+import Link from "next/link";
+import type { SharedList } from "@/lib/types";
+
+export function SharedListCard({ list }: { list: SharedList }) {
+  return (
+    <div className="rounded-md border border-zinc-200 bg-white p-3">
+      <Link
+        href={`/lists/${list.id}`}
+        className="block text-sm font-medium text-zinc-900 hover:underline"
+      >
+        {list.name}
+      </Link>
+      <p className="text-xs text-zinc-400">
+        Shared by {list.owner_email}
+      </p>
+    </div>
+  );
+}

--- a/src/lib/list-data.ts
+++ b/src/lib/list-data.ts
@@ -29,6 +29,8 @@ export type ListPageData = {
   stores: Store[];
   pricesByProduct: Map<string, ItemPriceWithStore[]>;
   allDiscounts: Discount[];
+  /** True if the current user owns this list, false if it's shared with them */
+  isOwner: boolean;
 };
 
 /**
@@ -131,5 +133,6 @@ export async function fetchListPageData(
     stores: (stores ?? []) as Store[],
     pricesByProduct,
     allDiscounts,
+    isOwner: list.user_id === user?.id,
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -99,6 +99,24 @@ export type Discount = {
   description: string | null;
 };
 
+/** A sharing record linking a list to a shared user */
+export type ListShare = {
+  id: string;
+  list_id: string;
+  user_id: string;
+};
+
+/**
+ * A shared list as returned by the get_shared_lists() database function.
+ * Includes the owner's email so we can show "Shared by [email]" in the UI.
+ */
+export type SharedList = {
+  id: string;
+  name: string;
+  created_at: string;
+  owner_email: string;
+};
+
 /** Best deal info for an item from the smart split calculation */
 export type BestDealInfo = {
   storeName: string;

--- a/supabase/migrations/phase8_fix_rls_recursion.sql
+++ b/supabase/migrations/phase8_fix_rls_recursion.sql
@@ -1,0 +1,54 @@
+-- ============================================================
+-- Phase 8 FIX: Break RLS infinite recursion
+-- Run this in the Supabase SQL Editor AFTER phase8_shared_lists.sql
+-- ============================================================
+--
+-- The Problem:
+-- shopping_lists RLS references list_shares, and list_shares RLS
+-- references shopping_lists. PostgreSQL detects this circular
+-- dependency and blocks ALL queries with:
+--   "infinite recursion detected in policy for relation shopping_lists"
+--
+-- The Fix:
+-- Create a SECURITY DEFINER function (is_list_owner) that checks
+-- list ownership WITHOUT triggering RLS. Then update list_shares
+-- policies to use this function instead of a direct subquery on
+-- shopping_lists. This breaks the cycle:
+--   shopping_lists → list_shares → is_list_owner() (no RLS) ✓
+-- ============================================================
+
+-- Helper function: checks if the current user owns a list.
+-- SECURITY DEFINER means this function bypasses RLS when querying
+-- shopping_lists, which prevents the circular reference.
+create or replace function is_list_owner(p_list_id uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1 from shopping_lists
+    where id = p_list_id and user_id = auth.uid()
+  );
+$$;
+
+-- Update list_shares policies to use is_list_owner() instead of
+-- a direct subquery on shopping_lists.
+
+drop policy "List owners and shared users can view shares" on list_shares;
+create policy "List owners and shared users can view shares"
+  on list_shares for select
+  using (
+    user_id = auth.uid()
+    or is_list_owner(list_id)
+  );
+
+drop policy "List owners can insert shares" on list_shares;
+create policy "List owners can insert shares"
+  on list_shares for insert
+  with check (is_list_owner(list_id));
+
+drop policy "List owners can delete shares" on list_shares;
+create policy "List owners can delete shares"
+  on list_shares for delete
+  using (is_list_owner(list_id));

--- a/supabase/migrations/phase8_shared_lists.sql
+++ b/supabase/migrations/phase8_shared_lists.sql
@@ -1,0 +1,344 @@
+-- ============================================================
+-- Phase 8: Shared Lists — Database Migration
+-- Run this in the Supabase SQL Editor (supabase dashboard)
+-- ============================================================
+--
+-- This migration does three things:
+-- 1. Creates helper functions to look up users by email (needed because
+--    auth.users isn't directly queryable from the client).
+-- 2. Updates RLS (Row Level Security) policies on 7 tables so that
+--    shared users can view and edit lists shared with them.
+-- 3. The list_shares table and its RLS policies already exist —
+--    no changes needed there.
+-- ============================================================
+
+
+-- ============================================
+-- HELPER FUNCTIONS
+-- ============================================
+-- These use SECURITY DEFINER to access the auth.users table,
+-- which isn't available to normal queries. SECURITY DEFINER means
+-- the function runs with the permissions of the user who created it
+-- (the database owner), not the user who calls it.
+-- ============================================
+
+-- Look up a user's ID by their email address.
+-- Used when the list owner types an email to share with.
+-- Returns null if no user exists with that email.
+create or replace function get_user_id_by_email(lookup_email text)
+returns uuid
+language sql
+security definer
+set search_path = public
+as $$
+  select id from auth.users where email = lookup_email;
+$$;
+
+-- Get all lists shared with the current user, including the owner's email.
+-- Used on the home page to show a "Shared with me" section.
+create or replace function get_shared_lists()
+returns table(id uuid, name text, created_at timestamptz, owner_email text)
+language sql
+security definer
+set search_path = public
+as $$
+  select sl.id, sl.name, sl.created_at, u.email as owner_email
+  from list_shares ls
+  join shopping_lists sl on sl.id = ls.list_id
+  join auth.users u on u.id = sl.user_id
+  where ls.user_id = auth.uid()
+    and sl.is_template = false
+  order by sl.created_at desc;
+$$;
+
+-- Get the list of users a specific list is shared with (including their emails).
+-- Only the list owner can call this (enforced by the EXISTS check).
+-- Used in the share management section on the list detail page.
+create or replace function get_list_shares_with_email(p_list_id uuid)
+returns table(id uuid, user_id uuid, email text)
+language sql
+security definer
+set search_path = public
+as $$
+  select ls.id, ls.user_id, u.email
+  from list_shares ls
+  join auth.users u on u.id = ls.user_id
+  where ls.list_id = p_list_id
+    and exists (
+      select 1 from shopping_lists sl
+      where sl.id = p_list_id
+        and sl.user_id = auth.uid()
+    );
+$$;
+
+
+-- ============================================
+-- RLS POLICY UPDATES
+-- ============================================
+-- For each table, we drop the old policy and create a new one that
+-- adds an OR condition for shared users. The pattern is:
+--   existing condition OR EXISTS (check list_shares)
+--
+-- We use a reusable subquery pattern:
+--   EXISTS (SELECT 1 FROM list_shares WHERE list_shares.list_id = ... AND list_shares.user_id = auth.uid())
+-- ============================================
+
+
+-- ── 1. shopping_lists ─────────────────────────────────────────────
+-- Shared users can VIEW lists shared with them (but not update/delete)
+
+drop policy "Users can view own lists" on shopping_lists;
+create policy "Users can view own and shared lists"
+  on shopping_lists for select
+  using (
+    user_id = auth.uid()
+    or exists (
+      select 1 from list_shares
+      where list_shares.list_id = shopping_lists.id
+        and list_shares.user_id = auth.uid()
+    )
+  );
+
+
+-- ── 2. list_items ─────────────────────────────────────────────────
+-- Shared users can fully CRUD items in shared lists
+
+drop policy "Users can view items in own lists" on list_items;
+create policy "Users can view items in own and shared lists"
+  on list_items for select
+  using (
+    exists (
+      select 1 from shopping_lists
+      where shopping_lists.id = list_items.list_id
+        and (
+          shopping_lists.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares
+            where list_shares.list_id = shopping_lists.id
+              and list_shares.user_id = auth.uid()
+          )
+        )
+    )
+  );
+
+drop policy "Users can insert items in own lists" on list_items;
+create policy "Users can insert items in own and shared lists"
+  on list_items for insert
+  with check (
+    exists (
+      select 1 from shopping_lists
+      where shopping_lists.id = list_items.list_id
+        and (
+          shopping_lists.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares
+            where list_shares.list_id = shopping_lists.id
+              and list_shares.user_id = auth.uid()
+          )
+        )
+    )
+  );
+
+drop policy "Users can update items in own lists" on list_items;
+create policy "Users can update items in own and shared lists"
+  on list_items for update
+  using (
+    exists (
+      select 1 from shopping_lists
+      where shopping_lists.id = list_items.list_id
+        and (
+          shopping_lists.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares
+            where list_shares.list_id = shopping_lists.id
+              and list_shares.user_id = auth.uid()
+          )
+        )
+    )
+  );
+
+drop policy "Users can delete items in own lists" on list_items;
+create policy "Users can delete items in own and shared lists"
+  on list_items for delete
+  using (
+    exists (
+      select 1 from shopping_lists
+      where shopping_lists.id = list_items.list_id
+        and (
+          shopping_lists.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares
+            where list_shares.list_id = shopping_lists.id
+              and list_shares.user_id = auth.uid()
+          )
+        )
+    )
+  );
+
+
+-- ── 3. products ───────────────────────────────────────────────────
+-- Shared users can view and create products in the list owner's catalog.
+-- This is needed because when a shared user adds an item to a shared list,
+-- the product must be in the owner's catalog (so prices stay consistent).
+
+drop policy "Users can view own products" on products;
+create policy "Users can view own and shared products"
+  on products for select
+  using (
+    user_id = auth.uid()
+    or exists (
+      select 1 from list_shares ls
+      join shopping_lists sl on sl.id = ls.list_id
+      where ls.user_id = auth.uid()
+        and sl.user_id = products.user_id
+    )
+  );
+
+drop policy "Users can insert own products" on products;
+create policy "Users can insert own and shared products"
+  on products for insert
+  with check (
+    user_id = auth.uid()
+    or exists (
+      select 1 from list_shares ls
+      join shopping_lists sl on sl.id = ls.list_id
+      where ls.user_id = auth.uid()
+        and sl.user_id = products.user_id
+    )
+  );
+
+
+-- ── 4. stores ─────────────────────────────────────────────────────
+-- Shared users can view the list owner's stores (to see store names
+-- in prices and the comparison dashboard). They cannot create/edit/delete.
+
+drop policy "Users can view own stores" on stores;
+create policy "Users can view own and shared stores"
+  on stores for select
+  using (
+    user_id = auth.uid()
+    or exists (
+      select 1 from list_shares ls
+      join shopping_lists sl on sl.id = ls.list_id
+      where ls.user_id = auth.uid()
+        and sl.user_id = stores.user_id
+    )
+  );
+
+
+-- ── 5. item_prices ────────────────────────────────────────────────
+-- Shared users can view, add, update, and delete prices for products
+-- in shared lists. The check goes through products → list_shares.
+
+drop policy "Users can view prices for own products" on item_prices;
+create policy "Users can view prices for own and shared products"
+  on item_prices for select
+  using (
+    exists (
+      select 1 from products
+      where products.id = item_prices.product_id
+        and (
+          products.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares ls
+            join shopping_lists sl on sl.id = ls.list_id
+            where ls.user_id = auth.uid()
+              and sl.user_id = products.user_id
+          )
+        )
+    )
+  );
+
+drop policy "Users can insert prices for own products" on item_prices;
+create policy "Users can insert prices for own and shared products"
+  on item_prices for insert
+  with check (
+    exists (
+      select 1 from products
+      where products.id = item_prices.product_id
+        and (
+          products.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares ls
+            join shopping_lists sl on sl.id = ls.list_id
+            where ls.user_id = auth.uid()
+              and sl.user_id = products.user_id
+          )
+        )
+    )
+  );
+
+drop policy "Users can update prices for own products" on item_prices;
+create policy "Users can update prices for own and shared products"
+  on item_prices for update
+  using (
+    exists (
+      select 1 from products
+      where products.id = item_prices.product_id
+        and (
+          products.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares ls
+            join shopping_lists sl on sl.id = ls.list_id
+            where ls.user_id = auth.uid()
+              and sl.user_id = products.user_id
+          )
+        )
+    )
+  );
+
+drop policy "Users can delete prices for own products" on item_prices;
+create policy "Users can delete prices for own and shared products"
+  on item_prices for delete
+  using (
+    exists (
+      select 1 from products
+      where products.id = item_prices.product_id
+        and (
+          products.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares ls
+            join shopping_lists sl on sl.id = ls.list_id
+            where ls.user_id = auth.uid()
+              and sl.user_id = products.user_id
+          )
+        )
+    )
+  );
+
+
+-- ── 6. discounts ──────────────────────────────────────────────────
+-- Shared users can view discounts (needed for price comparison).
+-- They cannot create/edit/delete discounts — only the owner can.
+
+drop policy "Users can view own discounts" on discounts;
+create policy "Users can view own and shared discounts"
+  on discounts for select
+  using (
+    user_id = auth.uid()
+    or exists (
+      select 1 from list_shares ls
+      join shopping_lists sl on sl.id = ls.list_id
+      where ls.user_id = auth.uid()
+        and sl.user_id = discounts.user_id
+    )
+  );
+
+
+-- ── 7. categories ─────────────────────────────────────────────────
+-- Shared users can see the list owner's custom categories (so items
+-- display correctly when a shared user views the list).
+
+drop policy "Users can view default and own categories" on categories;
+create policy "Users can view default own and shared categories"
+  on categories for select
+  using (
+    user_id is null
+    or user_id = auth.uid()
+    or exists (
+      select 1 from list_shares ls
+      join shopping_lists sl on sl.id = ls.list_id
+      where ls.user_id = auth.uid()
+        and sl.user_id = categories.user_id
+    )
+  );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -16,10 +16,20 @@ create table categories (
 
 alter table categories enable row level security;
 
--- Users can see default categories (user_id is null) and their own
-create policy "Users can view default and own categories"
+-- Users can see default categories (user_id is null), their own,
+-- and categories belonging to users who shared a list with them
+create policy "Users can view default own and shared categories"
   on categories for select
-  using (user_id is null or user_id = auth.uid());
+  using (
+    user_id is null
+    or user_id = auth.uid()
+    or exists (
+      select 1 from list_shares ls
+      join shopping_lists sl on sl.id = ls.list_id
+      where ls.user_id = auth.uid()
+        and sl.user_id = categories.user_id
+    )
+  );
 
 create policy "Users can insert own categories"
   on categories for insert
@@ -62,9 +72,17 @@ create table shopping_lists (
 
 alter table shopping_lists enable row level security;
 
-create policy "Users can view own lists"
+-- Users can view their own lists AND lists shared with them
+create policy "Users can view own and shared lists"
   on shopping_lists for select
-  using (user_id = auth.uid());
+  using (
+    user_id = auth.uid()
+    or exists (
+      select 1 from list_shares
+      where list_shares.list_id = shopping_lists.id
+        and list_shares.user_id = auth.uid()
+    )
+  );
 
 create policy "Users can insert own lists"
   on shopping_lists for insert
@@ -95,13 +113,33 @@ create table products (
 
 alter table products enable row level security;
 
-create policy "Users can view own products"
+-- Users can view their own products AND products belonging to users
+-- who shared a list with them (so prices display correctly)
+create policy "Users can view own and shared products"
   on products for select
-  using (user_id = auth.uid());
+  using (
+    user_id = auth.uid()
+    or exists (
+      select 1 from list_shares ls
+      join shopping_lists sl on sl.id = ls.list_id
+      where ls.user_id = auth.uid()
+        and sl.user_id = products.user_id
+    )
+  );
 
-create policy "Users can insert own products"
+-- Users can create products in their own catalog OR in the catalog
+-- of users who shared a list with them (for adding items to shared lists)
+create policy "Users can insert own and shared products"
   on products for insert
-  with check (user_id = auth.uid());
+  with check (
+    user_id = auth.uid()
+    or exists (
+      select 1 from list_shares ls
+      join shopping_lists sl on sl.id = ls.list_id
+      where ls.user_id = auth.uid()
+        and sl.user_id = products.user_id
+    )
+  );
 
 create policy "Users can update own products"
   on products for update
@@ -131,44 +169,73 @@ create table list_items (
 
 alter table list_items enable row level security;
 
--- RLS for list_items checks that the parent shopping_list belongs to the user
-create policy "Users can view items in own lists"
+-- RLS for list_items checks that the parent shopping_list belongs to
+-- the user OR is shared with them
+create policy "Users can view items in own and shared lists"
   on list_items for select
   using (
     exists (
       select 1 from shopping_lists
       where shopping_lists.id = list_items.list_id
-        and shopping_lists.user_id = auth.uid()
+        and (
+          shopping_lists.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares
+            where list_shares.list_id = shopping_lists.id
+              and list_shares.user_id = auth.uid()
+          )
+        )
     )
   );
 
-create policy "Users can insert items in own lists"
+create policy "Users can insert items in own and shared lists"
   on list_items for insert
   with check (
     exists (
       select 1 from shopping_lists
       where shopping_lists.id = list_items.list_id
-        and shopping_lists.user_id = auth.uid()
+        and (
+          shopping_lists.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares
+            where list_shares.list_id = shopping_lists.id
+              and list_shares.user_id = auth.uid()
+          )
+        )
     )
   );
 
-create policy "Users can update items in own lists"
+create policy "Users can update items in own and shared lists"
   on list_items for update
   using (
     exists (
       select 1 from shopping_lists
       where shopping_lists.id = list_items.list_id
-        and shopping_lists.user_id = auth.uid()
+        and (
+          shopping_lists.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares
+            where list_shares.list_id = shopping_lists.id
+              and list_shares.user_id = auth.uid()
+          )
+        )
     )
   );
 
-create policy "Users can delete items in own lists"
+create policy "Users can delete items in own and shared lists"
   on list_items for delete
   using (
     exists (
       select 1 from shopping_lists
       where shopping_lists.id = list_items.list_id
-        and shopping_lists.user_id = auth.uid()
+        and (
+          shopping_lists.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares
+            where list_shares.list_id = shopping_lists.id
+              and list_shares.user_id = auth.uid()
+          )
+        )
     )
   );
 
@@ -184,9 +251,19 @@ create table stores (
 
 alter table stores enable row level security;
 
-create policy "Users can view own stores"
+-- Users can view their own stores AND stores belonging to users
+-- who shared a list with them (so store names appear in prices)
+create policy "Users can view own and shared stores"
   on stores for select
-  using (user_id = auth.uid());
+  using (
+    user_id = auth.uid()
+    or exists (
+      select 1 from list_shares ls
+      join shopping_lists sl on sl.id = ls.list_id
+      where ls.user_id = auth.uid()
+        and sl.user_id = stores.user_id
+    )
+  );
 
 create policy "Users can insert own stores"
   on stores for insert
@@ -217,44 +294,76 @@ create table item_prices (
 
 alter table item_prices enable row level security;
 
--- RLS checks ownership through products.user_id
-create policy "Users can view prices for own products"
+-- RLS checks ownership through products.user_id, including shared access
+create policy "Users can view prices for own and shared products"
   on item_prices for select
   using (
     exists (
       select 1 from products
       where products.id = item_prices.product_id
-        and products.user_id = auth.uid()
+        and (
+          products.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares ls
+            join shopping_lists sl on sl.id = ls.list_id
+            where ls.user_id = auth.uid()
+              and sl.user_id = products.user_id
+          )
+        )
     )
   );
 
-create policy "Users can insert prices for own products"
+create policy "Users can insert prices for own and shared products"
   on item_prices for insert
   with check (
     exists (
       select 1 from products
       where products.id = item_prices.product_id
-        and products.user_id = auth.uid()
+        and (
+          products.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares ls
+            join shopping_lists sl on sl.id = ls.list_id
+            where ls.user_id = auth.uid()
+              and sl.user_id = products.user_id
+          )
+        )
     )
   );
 
-create policy "Users can update prices for own products"
+create policy "Users can update prices for own and shared products"
   on item_prices for update
   using (
     exists (
       select 1 from products
       where products.id = item_prices.product_id
-        and products.user_id = auth.uid()
+        and (
+          products.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares ls
+            join shopping_lists sl on sl.id = ls.list_id
+            where ls.user_id = auth.uid()
+              and sl.user_id = products.user_id
+          )
+        )
     )
   );
 
-create policy "Users can delete prices for own products"
+create policy "Users can delete prices for own and shared products"
   on item_prices for delete
   using (
     exists (
       select 1 from products
       where products.id = item_prices.product_id
-        and products.user_id = auth.uid()
+        and (
+          products.user_id = auth.uid()
+          or exists (
+            select 1 from list_shares ls
+            join shopping_lists sl on sl.id = ls.list_id
+            where ls.user_id = auth.uid()
+              and sl.user_id = products.user_id
+          )
+        )
     )
   );
 
@@ -276,9 +385,19 @@ create table discounts (
 
 alter table discounts enable row level security;
 
-create policy "Users can view own discounts"
+-- Users can view their own discounts AND discounts belonging to users
+-- who shared a list with them (needed for price comparison)
+create policy "Users can view own and shared discounts"
   on discounts for select
-  using (user_id = auth.uid());
+  using (
+    user_id = auth.uid()
+    or exists (
+      select 1 from list_shares ls
+      join shopping_lists sl on sl.id = ls.list_id
+      where ls.user_id = auth.uid()
+        and sl.user_id = discounts.user_id
+    )
+  );
 
 create policy "Users can insert own discounts"
   on discounts for insert
@@ -307,36 +426,90 @@ create table list_shares (
 
 alter table list_shares enable row level security;
 
--- Both the list owner and the shared user can see the share
+-- Both the list owner and the shared user can see the share.
+-- Uses is_list_owner() function instead of a direct subquery on
+-- shopping_lists to avoid infinite RLS recursion (shopping_lists
+-- RLS references list_shares, so list_shares can't reference back).
 create policy "List owners and shared users can view shares"
   on list_shares for select
   using (
     user_id = auth.uid()
-    or exists (
-      select 1 from shopping_lists
-      where shopping_lists.id = list_shares.list_id
-        and shopping_lists.user_id = auth.uid()
-    )
+    or is_list_owner(list_id)
   );
 
 -- Only the list owner can share the list with others
 create policy "List owners can insert shares"
   on list_shares for insert
-  with check (
-    exists (
-      select 1 from shopping_lists
-      where shopping_lists.id = list_shares.list_id
-        and shopping_lists.user_id = auth.uid()
-    )
-  );
+  with check (is_list_owner(list_id));
 
 -- Only the list owner can remove shares
 create policy "List owners can delete shares"
   on list_shares for delete
-  using (
-    exists (
-      select 1 from shopping_lists
-      where shopping_lists.id = list_shares.list_id
-        and shopping_lists.user_id = auth.uid()
-    )
+  using (is_list_owner(list_id));
+
+
+-- ============================================
+-- HELPER FUNCTIONS
+-- These use SECURITY DEFINER to run with elevated permissions.
+-- Used for accessing auth.users (not directly queryable) and
+-- for breaking RLS circular references.
+-- ============================================
+
+-- Check if the current user owns a specific list.
+-- Used in list_shares RLS to avoid infinite recursion
+-- (shopping_lists RLS → list_shares → is_list_owner bypasses RLS).
+create or replace function is_list_owner(p_list_id uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1 from shopping_lists
+    where id = p_list_id and user_id = auth.uid()
   );
+$$;
+
+-- Look up a user's ID by their email address (for sharing)
+create or replace function get_user_id_by_email(lookup_email text)
+returns uuid
+language sql
+security definer
+set search_path = public
+as $$
+  select id from auth.users where email = lookup_email;
+$$;
+
+-- Get all lists shared with the current user, including the owner's email
+create or replace function get_shared_lists()
+returns table(id uuid, name text, created_at timestamptz, owner_email text)
+language sql
+security definer
+set search_path = public
+as $$
+  select sl.id, sl.name, sl.created_at, u.email as owner_email
+  from list_shares ls
+  join shopping_lists sl on sl.id = ls.list_id
+  join auth.users u on u.id = sl.user_id
+  where ls.user_id = auth.uid()
+    and sl.is_template = false
+  order by sl.created_at desc;
+$$;
+
+-- Get the list of users a specific list is shared with (owner only)
+create or replace function get_list_shares_with_email(p_list_id uuid)
+returns table(id uuid, user_id uuid, email text)
+language sql
+security definer
+set search_path = public
+as $$
+  select ls.id, ls.user_id, u.email
+  from list_shares ls
+  join auth.users u on u.id = ls.user_id
+  where ls.list_id = p_list_id
+    and exists (
+      select 1 from shopping_lists sl
+      where sl.id = p_list_id
+        and sl.user_id = auth.uid()
+    );
+$$;


### PR DESCRIPTION
## What
Add list sharing so users can collaborate on shopping lists by inviting others via email.

## Why
Phase 8 of the project roadmap — shared lists let household members or friends view and edit the same shopping list, check off items while shopping, and see the same price comparisons.

## Jira related ticket
- N/A

## Changes

**Database (SQL migrations to run in Supabase Dashboard):**
- Add 4 helper functions: `is_list_owner`, `get_user_id_by_email`, `get_shared_lists`, `get_list_shares_with_email`
- Update RLS SELECT policies on 7 tables (shopping_lists, list_items, products, stores, item_prices, discounts, categories) to grant shared users access
- Update RLS INSERT/UPDATE/DELETE policies on list_items, products, and item_prices for shared editing
- Fix infinite RLS recursion between shopping_lists and list_shares by using a SECURITY DEFINER function (`is_list_owner`) in list_shares policies

**Server Actions (`actions.ts`):**
- Add `shareList` and `unshareList` actions
- Add `getListOwnerId` helper — used by `addItem`/`updateItem` to create products in the list owner's catalog (keeps prices consistent across collaborators)

**Home page (`page.tsx`):**
- Fetch owned lists and shared lists in parallel
- Show "Shared with me" section with owner email

**List detail page (`lists/[id]/page.tsx`):**
- Show share management section for list owners (add/remove users by email)
- Show "Shared with you" badge for collaborators
- Shopping mode and price comparison work automatically via RLS updates

**New components:**
- `ShareListSection.tsx` — email input + shared users list with remove buttons
- `SharedListCard.tsx` — read-only card showing list name + owner email

**Types (`types.ts`, `list-data.ts`):**
- Add `ListShare`, `SharedList` types
- Add `isOwner` flag to `ListPageData`

## Testing
1. Run the two SQL migration files in Supabase Dashboard (phase8_shared_lists.sql first, then phase8_fix_rls_recursion.sql)
2. Verify existing data reappears after the RLS fix migration
3. Test sharing: owner shares list by email → shared user sees it under "Shared with me"
4. Test collaborative editing: shared user can add/edit/delete items, check items, view prices
5. Test unsharing: owner removes a shared user → list disappears from their home page
6. Test edge cases: share with yourself (error), share with non-existent email (error), duplicate share (error)
7. Run `npm run build` — passes

## Screenshot
N/A — no visual design changes beyond new share section

## Checklist
- `npm run build` passes
- Visual verification done (via Playwright debug script)
- RLS recursion fix verified via direct Supabase API queries