### PR TITLE
feat: add template lists with recurrence reminders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ yarn-error.log*
 /playwright/.cache/
 /e2e/.auth/
 
+# supabase
+supabase/.temp/
+
 # vercel
 .vercel
 

--- a/src/app/(protected)/actions.ts
+++ b/src/app/(protected)/actions.ts
@@ -14,6 +14,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
@@ -1180,5 +1181,301 @@ export async function unshareList(
   }
 
   revalidatePath(`/lists/${listId}`);
+  return { error: null };
+}
+
+// ─── Template Actions ────────────────────────────────────────
+
+/**
+ * Copy all items from one list to another.
+ *
+ * Used by both "Save as Template" and "Create from Template" to avoid
+ * duplicating the item-copying logic. Copies name, product link,
+ * quantity, unit, and category — checked defaults to false.
+ */
+async function copyListItems(
+  supabase: SupabaseClient,
+  sourceListId: string,
+  targetListId: string
+): Promise<{ error: string | null }> {
+  const { data: sourceItems } = await supabase
+    .from("list_items")
+    .select("name, product_id, quantity, unit, category_id")
+    .eq("list_id", sourceListId);
+
+  if (sourceItems && sourceItems.length > 0) {
+    const newItems = sourceItems.map((item) => ({
+      list_id: targetListId,
+      name: item.name,
+      product_id: item.product_id,
+      quantity: item.quantity,
+      unit: item.unit,
+      category_id: item.category_id,
+    }));
+
+    const { error } = await supabase.from("list_items").insert(newItems);
+    if (error) return { error: "Could not copy items." };
+  }
+
+  return { error: null };
+}
+
+/**
+ * Create a new empty template from scratch.
+ *
+ * Unlike saveAsTemplate (which copies an existing list), this creates
+ * a blank template that the user can then add items to.
+ */
+export async function createTemplate(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const name = formData.get("name") as string;
+
+  if (!name || name.trim().length === 0) {
+    return { error: "Please enter a template name." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  const { error } = await supabase
+    .from("shopping_lists")
+    .insert({ name: name.trim(), user_id: user.id, is_template: true });
+
+  if (error) {
+    return { error: "Could not create template. Please try again." };
+  }
+
+  revalidatePath("/templates");
+  return { error: null };
+}
+
+/**
+ * Save an existing shopping list as a reusable template.
+ *
+ * This creates a COPY of the list with is_template = true, then copies
+ * all the list items into the new template. The original list is unchanged.
+ * Think of it like "Save As" — the template is a separate snapshot.
+ */
+export async function saveAsTemplate(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const listId = formData.get("list_id") as string;
+
+  if (!listId) {
+    return { error: "Missing list ID." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  // Fetch the source list to get its name
+  const { data: sourceList } = await supabase
+    .from("shopping_lists")
+    .select("name")
+    .eq("id", listId)
+    .single();
+
+  if (!sourceList) {
+    return { error: "List not found." };
+  }
+
+  // Create the template (a new shopping_lists row with is_template = true)
+  const { data: template, error: createError } = await supabase
+    .from("shopping_lists")
+    .insert({
+      name: sourceList.name,
+      user_id: user.id,
+      is_template: true,
+    })
+    .select("id")
+    .single();
+
+  if (createError || !template) {
+    return { error: "Could not create template. Please try again." };
+  }
+
+  // Copy all items from the source list into the template
+  const copyResult = await copyListItems(supabase, listId, template.id);
+  if (copyResult.error) {
+    return { error: "Template created but could not copy items." };
+  }
+
+  // Redirect to the templates page so the user sees their new template
+  redirect("/templates");
+}
+
+/**
+ * Create a new shopping list from a template.
+ *
+ * Copies the template's items into a fresh list. The template stays
+ * unchanged — you can use it again and again. Also updates the
+ * template's last_used_at so the recurrence reminder knows when
+ * this template was last used.
+ */
+export async function createListFromTemplate(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const templateId = formData.get("template_id") as string;
+
+  if (!templateId) {
+    return { error: "Missing template ID." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  // Fetch the template to get its name and verify it's a template
+  const { data: template } = await supabase
+    .from("shopping_lists")
+    .select("name, is_template")
+    .eq("id", templateId)
+    .single();
+
+  if (!template) {
+    return { error: "Template not found." };
+  }
+
+  if (!template.is_template) {
+    return { error: "This list is not a template." };
+  }
+
+  // Create a new regular list with the template's name
+  const { data: newList, error: createError } = await supabase
+    .from("shopping_lists")
+    .insert({
+      name: template.name,
+      user_id: user.id,
+      is_template: false,
+    })
+    .select("id")
+    .single();
+
+  if (createError || !newList) {
+    return { error: "Could not create list. Please try again." };
+  }
+
+  // Copy items and update last_used_at
+  const copyResult = await copyListItems(supabase, templateId, newList.id);
+  if (copyResult.error) {
+    return { error: "List created but could not copy items." };
+  }
+
+  // Update last_used_at so the recurrence reminder resets.
+  // For example, if this is a weekly template, the reminder won't
+  // show again until 7 days from now.
+  await supabase
+    .from("shopping_lists")
+    .update({ last_used_at: new Date().toISOString() })
+    .eq("id", templateId);
+
+  // Redirect to the new list so the user can start using it
+  redirect(`/lists/${newList.id}`);
+}
+
+/**
+ * Update a template's name and/or recurrence schedule.
+ *
+ * Recurrence controls how often the app reminds you to create a new
+ * list from this template: "weekly" (every 7 days), "monthly" (every
+ * 30 days), or null (no reminders).
+ */
+export async function updateTemplate(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const id = formData.get("id") as string;
+  const name = formData.get("name") as string;
+  const recurrenceRaw = formData.get("recurrence") as string;
+
+  if (!name || name.trim().length === 0) {
+    return { error: "Template name cannot be empty." };
+  }
+
+  // Convert empty string to null (the <select> sends "" for "None")
+  const recurrence =
+    recurrenceRaw === "weekly" || recurrenceRaw === "monthly"
+      ? recurrenceRaw
+      : null;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  const { error } = await supabase
+    .from("shopping_lists")
+    .update({ name: name.trim(), recurrence })
+    .eq("id", id);
+
+  if (error) {
+    return { error: "Could not update template. Please try again." };
+  }
+
+  revalidatePath("/templates");
+  return { error: null };
+}
+
+/**
+ * Delete a template.
+ *
+ * This also deletes all list_items in the template because the
+ * database schema uses ON DELETE CASCADE on foreign keys.
+ * Lists previously created from this template are NOT affected.
+ */
+export async function deleteTemplate(
+  previousState: ActionResult,
+  formData: FormData
+): Promise<ActionResult> {
+  const id = formData.get("id") as string;
+
+  if (!id) {
+    return { error: "Missing template ID." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in." };
+  }
+
+  const { error } = await supabase
+    .from("shopping_lists")
+    .delete()
+    .eq("id", id);
+
+  if (error) {
+    return { error: "Could not delete template. Please try again." };
+  }
+
+  revalidatePath("/templates");
   return { error: null };
 }

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -59,6 +59,12 @@ export default async function ProtectedLayout({
             >
               Products
             </Link>
+            <Link
+              href="/templates"
+              className="text-sm text-zinc-500 hover:text-zinc-700"
+            >
+              Templates
+            </Link>
           </nav>
         </div>
         <div className="flex items-center gap-3">

--- a/src/app/(protected)/lists/[id]/page.tsx
+++ b/src/app/(protected)/lists/[id]/page.tsx
@@ -7,6 +7,8 @@ import { ListItemCard } from "@/components/ListItemCard";
 import { ItemPricesSection } from "@/components/ItemPricesSection";
 import { EmptyItemState } from "@/components/EmptyItemState";
 import { ShareListSection } from "@/components/ShareListSection";
+import { SubmitButton } from "@/components/SubmitButton";
+import { ActionFormButton } from "@/components/ActionFormButton";
 import {
   addItem,
   updateItem,
@@ -20,6 +22,8 @@ import {
   deleteDiscount,
   shareList,
   unshareList,
+  saveAsTemplate,
+  createListFromTemplate,
 } from "@/app/(protected)/actions";
 import { groupItemsByCategory } from "@/lib/list-helpers";
 
@@ -75,19 +79,27 @@ export default async function ListDetailPage({
 
   return (
     <div>
+      {/* Back link — goes to /templates when viewing a template, / otherwise */}
       <Link
-        href="/"
+        href={list.is_template ? "/templates" : "/"}
         className="text-sm text-zinc-500 hover:text-zinc-700"
       >
-        &larr; Back to lists
+        &larr; {list.is_template ? "Back to templates" : "Back to lists"}
       </Link>
 
-      <div className="mt-3 flex items-center justify-between">
+      <div className="mt-3 flex items-center gap-2">
         <h2 className="text-xl font-semibold">{list.name}</h2>
+        {/* Recurrence badge — shown on templates with a schedule */}
+        {list.is_template && list.recurrence && (
+          <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs text-blue-700">
+            {list.recurrence === "weekly" ? "Weekly" : "Monthly"}
+          </span>
+        )}
+      </div>
 
-        <div className="flex items-center gap-2">
-          {/* Show "Start Shopping" when the list has items */}
-          {items.length > 0 && (
+      <div className="mt-2 flex flex-wrap items-center justify-center gap-2">
+          {/* Regular list buttons — shopping and compare */}
+          {!list.is_template && items.length > 0 && (
             <Link
               href={`/lists/${id}/shop`}
               className="rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700"
@@ -96,8 +108,7 @@ export default async function ListDetailPage({
             </Link>
           )}
 
-          {/* Show "Compare Prices" link only when there are prices to compare */}
-          {pricesByProduct.size > 0 && (
+          {!list.is_template && pricesByProduct.size > 0 && (
             <Link
               href={`/lists/${id}/compare`}
               className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-800"
@@ -105,7 +116,35 @@ export default async function ListDetailPage({
               Compare Prices
             </Link>
           )}
-        </div>
+
+          {/* Use Template — creates a new list and redirects to it.
+              Uses a plain form (not ActionFormButton) because the server
+              action calls redirect(), which doesn't return a result.
+              .bind(null, ...) pre-fills the previousState argument so the
+              form only needs to pass formData. */}
+          {list.is_template && (
+            <form action={createListFromTemplate.bind(null, { error: null }) as unknown as (formData: FormData) => void}>
+              <input type="hidden" name="template_id" value={id} />
+              <SubmitButton
+                label="Use Template"
+                pendingLabel="Creating..."
+                className="rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+              />
+            </form>
+          )}
+
+          {/* Save as Template — only on regular lists the user owns */}
+          {!list.is_template && isOwner && (
+            <ActionFormButton
+              action={saveAsTemplate}
+              hiddenInputName="list_id"
+              hiddenInputValue={id}
+              label="Save as Template"
+              pendingLabel="Saving..."
+              successMessage="Template saved!"
+              buttonClassName="rounded-md border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-100 disabled:opacity-50"
+            />
+          )}
       </div>
 
       {/* Share management — only visible to the list owner */}

--- a/src/app/(protected)/page.tsx
+++ b/src/app/(protected)/page.tsx
@@ -4,6 +4,7 @@ import { ShoppingListForm } from "@/components/ShoppingListForm";
 import { ShoppingListCard } from "@/components/ShoppingListCard";
 import { SharedListCard } from "@/components/SharedListCard";
 import { EmptyListState } from "@/components/EmptyListState";
+import { TemplateReminderBanner } from "@/components/TemplateReminderBanner";
 import type { ShoppingList, SharedList } from "@/lib/types";
 
 /**
@@ -24,25 +25,49 @@ export default async function HomePage() {
     data: { user },
   } = await supabase.auth.getUser();
 
-  // Fetch owned lists and shared lists in parallel (independent queries).
+  // Fetch owned lists, shared lists, and recurring templates in parallel.
   // - Owned lists: filter by user_id explicitly so RLS-visible shared lists
   //   aren't included (we show those separately with owner email from the RPC).
   // - Shared lists: uses a database function that joins auth.users for email.
-  const [{ data: lists }, { data: sharedListsData }] = await Promise.all([
-    supabase
-      .from("shopping_lists")
-      .select("*")
-      .eq("user_id", user!.id)
-      .eq("is_template", false)
-      .order("created_at", { ascending: false }),
-    supabase.rpc("get_shared_lists"),
-  ]);
+  // - Recurring templates: templates with a recurrence set, for reminder banners.
+  const [{ data: lists }, { data: sharedListsData }, { data: recurringData }] =
+    await Promise.all([
+      supabase
+        .from("shopping_lists")
+        .select("*")
+        .eq("user_id", user!.id)
+        .eq("is_template", false)
+        .order("created_at", { ascending: false }),
+      supabase.rpc("get_shared_lists"),
+      supabase
+        .from("shopping_lists")
+        .select("*")
+        .eq("user_id", user!.id)
+        .eq("is_template", true)
+        .not("recurrence", "is", null),
+    ]);
 
   const shoppingLists = (lists ?? []) as ShoppingList[];
   const sharedLists = (sharedListsData ?? []) as SharedList[];
+  const recurringTemplates = (recurringData ?? []) as ShoppingList[];
+
+  // Find templates that are "due" — their recurrence period has passed.
+  // We compare last_used_at (or created_at if never used) against the threshold.
+  const now = new Date();
+  const dueTemplates = recurringTemplates.filter((t) => {
+    const lastUsed = new Date(t.last_used_at ?? t.created_at);
+    const daysSinceUse =
+      (now.getTime() - lastUsed.getTime()) / (1000 * 60 * 60 * 24);
+    if (t.recurrence === "weekly") return daysSinceUse >= 7;
+    if (t.recurrence === "monthly") return daysSinceUse >= 30;
+    return false;
+  });
 
   return (
     <div className="flex flex-col gap-4">
+      {/* Reminder banners for templates that are due */}
+      <TemplateReminderBanner dueTemplates={dueTemplates} />
+
       <h2 className="text-xl font-semibold">My Shopping Lists</h2>
 
       {/* Form to create a new list — always visible at the top */}

--- a/src/app/(protected)/templates/page.tsx
+++ b/src/app/(protected)/templates/page.tsx
@@ -1,0 +1,68 @@
+import { createClient } from "@/lib/supabase/server";
+import {
+  createTemplate,
+  updateTemplate,
+  deleteTemplate,
+  createListFromTemplate,
+} from "../actions";
+import { ShoppingListForm } from "@/components/ShoppingListForm";
+import { TemplateCard } from "@/components/TemplateCard";
+import { EmptyTemplateState } from "@/components/EmptyTemplateState";
+import type { ShoppingList } from "@/lib/types";
+
+/**
+ * Templates page — shows all of the user's reusable list templates.
+ *
+ * Templates are shopping lists with is_template = true. Users create
+ * them by clicking "Save as Template" on a regular list. From here,
+ * they can use a template to create a new list, edit it, or delete it.
+ *
+ * This is a Server Component — it fetches data directly from Supabase.
+ */
+export default async function TemplatesPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Fetch all templates with their item counts in a single query.
+  // Supabase's .select("*, list_items(count)") joins the related table
+  // and returns the count inline, avoiding a second query.
+  const { data: templatesData } = await supabase
+    .from("shopping_lists")
+    .select("*, list_items(count)")
+    .eq("user_id", user!.id)
+    .eq("is_template", true)
+    .order("created_at", { ascending: false });
+
+  const templates = (templatesData ?? []) as (ShoppingList & {
+    list_items: [{ count: number }];
+  })[];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h2 className="text-xl font-semibold">My Templates</h2>
+
+      {/* Form to create a new empty template */}
+      <ShoppingListForm createAction={createTemplate} placeholder="New template name..." />
+
+      {templates.length === 0 ? (
+        <EmptyTemplateState />
+      ) : (
+        <div className="flex flex-col gap-2">
+          {templates.map((template) => (
+            <TemplateCard
+              key={template.id}
+              template={template}
+              itemCount={template.list_items[0]?.count ?? 0}
+              updateAction={updateTemplate}
+              deleteAction={deleteTemplate}
+              createFromTemplateAction={createListFromTemplate}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ActionFormButton.tsx
+++ b/src/components/ActionFormButton.tsx
@@ -1,0 +1,82 @@
+/**
+ * A reusable button that submits a Server Action via a form.
+ *
+ * After a successful action, it shows a brief success message instead
+ * of the button. This pattern is used for one-click actions like
+ * "Save as Template" and "Create List from Template".
+ *
+ * "use client" is needed because we use useActionState for the
+ * Server Action and useState for the success message.
+ */
+"use client";
+
+import { useActionState, useState } from "react";
+import { SubmitButton } from "@/components/SubmitButton";
+import type { ActionResult } from "@/app/(protected)/actions";
+
+export function ActionFormButton({
+  action,
+  hiddenInputName,
+  hiddenInputValue,
+  label,
+  pendingLabel,
+  successMessage,
+  buttonClassName,
+}: {
+  /** The Server Action to call when the form is submitted */
+  action: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+  /** The name attribute for the hidden input (e.g., "list_id") */
+  hiddenInputName: string;
+  /** The value for the hidden input (e.g., the list's UUID) */
+  hiddenInputValue: string;
+  /** Button label shown before clicking */
+  label: string;
+  /** Button label shown while the action is running */
+  pendingLabel: string;
+  /** Message shown after successful action */
+  successMessage: string;
+  /** Tailwind classes for the button */
+  buttonClassName: string;
+}) {
+  const [done, setDone] = useState(false);
+
+  const [state, formAction] = useActionState(
+    async (previousState: ActionResult, formData: FormData) => {
+      const result = await action(previousState, formData);
+      if (!result.error) {
+        setDone(true);
+      }
+      return result;
+    },
+    { error: null }
+  );
+
+  if (done) {
+    return (
+      <p className="rounded-md bg-green-50 px-3 py-1.5 text-sm text-green-700">
+        {successMessage}
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <form action={formAction}>
+        <input type="hidden" name={hiddenInputName} value={hiddenInputValue} />
+        <SubmitButton
+          label={label}
+          pendingLabel={pendingLabel}
+          className={buttonClassName}
+        />
+      </form>
+      {state.error && (
+        <p className="mt-2 rounded-md bg-red-50 p-2 text-sm text-red-600">
+          {state.error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/EmptyTemplateState.tsx
+++ b/src/components/EmptyTemplateState.tsx
@@ -1,0 +1,16 @@
+/**
+ * Shown when the user has no templates yet.
+ *
+ * Guides the user to create their first template by saving an
+ * existing shopping list as a template.
+ */
+export function EmptyTemplateState() {
+  return (
+    <div className="py-12 text-center">
+      <p className="text-lg font-medium text-zinc-400">No templates yet</p>
+      <p className="mt-1 text-sm text-zinc-400">
+        Open a shopping list and tap &quot;Save as Template&quot; to create one!
+      </p>
+    </div>
+  );
+}

--- a/src/components/ShoppingListForm.tsx
+++ b/src/components/ShoppingListForm.tsx
@@ -13,12 +13,15 @@ import type { ActionResult } from "@/app/(protected)/actions";
 
 export function ShoppingListForm({
   createAction,
+  placeholder = "New list name...",
 }: {
   /** The Server Action to call when the form is submitted */
   createAction: (
     previousState: ActionResult,
     formData: FormData
   ) => Promise<ActionResult>;
+  /** Placeholder text for the input field */
+  placeholder?: string;
 }) {
   // We use a ref to access the form element so we can clear the input
   // after a successful submission.
@@ -51,7 +54,7 @@ export function ShoppingListForm({
         <input
           type="text"
           name="name"
-          placeholder="New list name..."
+          placeholder={placeholder}
           required
           className="flex-1 rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none"
         />

--- a/src/components/TemplateCard.tsx
+++ b/src/components/TemplateCard.tsx
@@ -1,0 +1,183 @@
+/**
+ * A card that displays a single template.
+ *
+ * Has three modes:
+ * 1. View mode (default) — shows the template name, recurrence badge,
+ *    item count, and action buttons (Use Template, Edit, Delete).
+ * 2. Edit mode — name input + recurrence select with save/cancel.
+ *
+ * "use client" is needed because we use useState to toggle between modes
+ * and useActionState for the Server Actions.
+ */
+"use client";
+
+import { useState, useActionState } from "react";
+import Link from "next/link";
+import { SubmitButton } from "@/components/SubmitButton";
+import type { ShoppingList } from "@/lib/types";
+import type { ActionResult } from "@/app/(protected)/actions";
+
+export function TemplateCard({
+  template,
+  itemCount,
+  updateAction,
+  deleteAction,
+  createFromTemplateAction,
+}: {
+  /** The template data to display */
+  template: ShoppingList;
+  /** How many items this template has */
+  itemCount: number;
+  /** Server Action to update name/recurrence */
+  updateAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+  /** Server Action to delete the template */
+  deleteAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+  /** Server Action to create a new list from this template */
+  createFromTemplateAction: (
+    previousState: ActionResult,
+    formData: FormData
+  ) => Promise<ActionResult>;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+
+  // Track errors from each action
+  const [updateState, updateFormAction] = useActionState(
+    async (previousState: ActionResult, formData: FormData) => {
+      const result = await updateAction(previousState, formData);
+      if (!result.error) {
+        setIsEditing(false);
+      }
+      return result;
+    },
+    { error: null }
+  );
+  const [deleteState, deleteFormAction] = useActionState(deleteAction, {
+    error: null,
+  });
+  const [createState, createFormAction] = useActionState(
+    createFromTemplateAction,
+    { error: null }
+  );
+
+  const error = updateState.error || deleteState.error || createState.error;
+
+  return (
+    <div className="rounded-md border border-zinc-200 bg-white p-3">
+      {isEditing ? (
+        // ─── Edit Mode ───
+        <form action={updateFormAction} className="flex flex-col gap-2">
+          <input type="hidden" name="id" value={template.id} />
+          <input
+            type="text"
+            name="name"
+            defaultValue={template.name}
+            required
+            autoFocus
+            className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm focus:border-zinc-500 focus:outline-none"
+          />
+          {/* Recurrence select — controls how often the app reminds you */}
+          <select
+            name="recurrence"
+            defaultValue={template.recurrence ?? ""}
+            className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm focus:border-zinc-500 focus:outline-none"
+          >
+            <option value="">No reminder</option>
+            <option value="weekly">Weekly reminder</option>
+            <option value="monthly">Monthly reminder</option>
+          </select>
+          <div className="flex gap-2">
+            <SubmitButton
+              label="Save"
+              pendingLabel="Saving..."
+              className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+            />
+            <button
+              type="button"
+              onClick={() => setIsEditing(false)}
+              className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm text-zinc-600 hover:bg-zinc-100"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : (
+        // ─── View Mode ───
+        <div className="flex items-center justify-between">
+          <div className="min-w-0 flex-1 flex flex-col justify-center">
+            <div className="flex items-center gap-2">
+              <Link
+                href={`/lists/${template.id}`}
+                className="text-sm font-medium text-zinc-900 hover:underline"
+              >
+                {template.name}
+              </Link>
+              {/* Recurrence badge — small colored label */}
+              {template.recurrence && (
+                <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs text-blue-700">
+                  {template.recurrence === "weekly" ? "Weekly" : "Monthly"}
+                </span>
+              )}
+            </div>
+            <p className="text-xs text-zinc-400">
+              {itemCount} {itemCount === 1 ? "item" : "items"}
+            </p>
+          </div>
+
+          <div className="flex items-center gap-1">
+            {/* Use Template — creates a new list from this template */}
+            <form action={createFormAction}>
+              <input type="hidden" name="template_id" value={template.id} />
+              <SubmitButton
+                label="Use Template"
+                pendingLabel="..."
+                className="rounded-md bg-green-600 px-2 py-1 text-xs font-medium text-white hover:bg-green-700 disabled:opacity-50"
+              />
+            </form>
+
+            <button
+              onClick={() => setIsEditing(true)}
+              className="rounded-md px-2 py-1 text-xs text-zinc-500 hover:bg-zinc-100"
+              aria-label={`Edit ${template.name}`}
+            >
+              Edit
+            </button>
+
+            <form
+              className="flex"
+              action={deleteFormAction}
+              onSubmit={(e) => {
+                const confirmed = window.confirm(
+                  `Delete template "${template.name}"? This cannot be undone.`
+                );
+                if (!confirmed) {
+                  e.preventDefault();
+                }
+              }}
+            >
+              <input type="hidden" name="id" value={template.id} />
+              <button
+                type="submit"
+                className="rounded-md px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+              >
+                Delete
+              </button>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Show error from any action */}
+      {error && (
+        <p className="mt-2 rounded-md bg-red-50 p-2 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/TemplateReminderBanner.tsx
+++ b/src/components/TemplateReminderBanner.tsx
@@ -1,0 +1,50 @@
+/**
+ * Shows reminder banners for templates that are "due".
+ *
+ * A template is due when its recurrence period has passed since last use:
+ * - Weekly templates: due after 7 days
+ * - Monthly templates: due after 30 days
+ *
+ * Each banner links to the /templates page where the user can create
+ * a new list from the template.
+ *
+ * This is a Server Component — no interactivity needed, it just
+ * displays information and links.
+ */
+
+import Link from "next/link";
+import type { ShoppingList } from "@/lib/types";
+
+export function TemplateReminderBanner({
+  dueTemplates,
+}: {
+  /** Templates whose recurrence period has passed */
+  dueTemplates: ShoppingList[];
+}) {
+  if (dueTemplates.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {dueTemplates.map((template) => (
+        <div
+          key={template.id}
+          className="flex items-center justify-between rounded-md border border-amber-200 bg-amber-50 p-3"
+        >
+          <p className="text-sm text-amber-800">
+            Time to create a new{" "}
+            <span className="font-medium">&quot;{template.name}&quot;</span>{" "}
+            list!
+          </p>
+          <Link
+            href="/templates"
+            className="shrink-0 rounded-md bg-amber-600 px-3 py-1 text-xs font-medium text-white hover:bg-amber-700"
+          >
+            View Templates
+          </Link>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,6 +13,7 @@ export type ShoppingList = {
   created_at: string;
   is_template: boolean;
   recurrence: "weekly" | "monthly" | null;
+  last_used_at: string | null;
 };
 
 /** A category as stored in the categories table */

--- a/supabase/migrations/phase9_template_lists.sql
+++ b/supabase/migrations/phase9_template_lists.sql
@@ -1,0 +1,9 @@
+-- ============================================================
+-- Phase 9: Template Lists
+--
+-- Adds a last_used_at column to shopping_lists so we can track
+-- when a template was last used to create a new list. This powers
+-- the recurrence reminder ("time to create a new list!").
+-- ============================================================
+
+ALTER TABLE shopping_lists ADD COLUMN last_used_at timestamptz;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -67,7 +67,8 @@ create table shopping_lists (
   name text not null,
   created_at timestamptz default now() not null,
   is_template boolean default false not null,
-  recurrence text check (recurrence in ('weekly', 'monthly'))
+  recurrence text check (recurrence in ('weekly', 'monthly')),
+  last_used_at timestamptz
 );
 
 alter table shopping_lists enable row level security;


### PR DESCRIPTION
## What
Add reusable template lists with optional weekly/monthly recurrence reminders.

## Why
Users recreate the same shopping lists frequently (e.g., "Weekly Groceries"). Templates let them save a list once and create new copies from it anytime, saving repetitive work.

## Jira related ticket
- N/A

## Changes
- **Database:** Add `last_used_at` column to `shopping_lists` for tracking recurrence (migration + schema)
- **Server actions:** Add 6 new actions — `createTemplate`, `saveAsTemplate`, `createListFromTemplate`, `updateTemplate`, `deleteTemplate`, and `copyListItems` helper
- **Templates page** (`/templates`): New page listing all templates with item counts, create form, and template cards with Use/Edit/Delete actions
- **Template cards:** View mode with recurrence badge and item count, edit mode with name + recurrence select
- **List detail page:** "Save as Template" button on owned lists; template view mode with "Use Template" button, recurrence badge, and back link to `/templates`
- **Home page:** Reminder banners for weekly/monthly templates that are due
- **Shared components:** `ActionFormButton` (reusable one-click action button), `EmptyTemplateState`, `TemplateReminderBanner`
- **Navigation:** Add "Templates" link to header
- **ShoppingListForm:** Add configurable `placeholder` prop for reuse on templates page

## Testing
1. Create a shopping list with items → click "Save as Template" → verify redirect to `/templates` with new template
2. On `/templates`, create an empty template via the form → click template name → add items
3. Click "Use Template" → verify redirect to new list with copied items
4. Edit template name/recurrence → verify changes persist
5. Delete a template → verify removal
6. Set recurrence to "weekly" → manually set `last_used_at` to 8+ days ago in DB → verify reminder banner on home page
7. Run `npm run build` — passes with no errors

## Screenshot
N/A — mobile-first UI, recommend testing on device/responsive mode

## Checklist
- `npm run build` passes
- Visual verification done