### PR TITLE
feat: add template lists with voice input

### DIFF
--- a/src/components/AddItemForm.test.tsx
+++ b/src/components/AddItemForm.test.tsx
@@ -14,6 +14,20 @@ jest.mock("react-dom", () => ({
   useFormStatus: () => ({ pending: false }),
 }));
 
+// Mock the voice input hook — default: not supported (jsdom has no Speech API)
+const mockStartListening = jest.fn();
+const mockStopListening = jest.fn();
+let mockVoiceSupported = false;
+
+jest.mock("@/hooks/useVoiceInput", () => ({
+  useVoiceInput: () => ({
+    isSupported: mockVoiceSupported,
+    isListening: false,
+    startListening: mockStartListening,
+    stopListening: mockStopListening,
+  }),
+}));
+
 const mockCategories: Category[] = [
   { id: "cat-1", user_id: null, name: "Beverages" },
   { id: "cat-2", user_id: null, name: "Fruits" },
@@ -126,5 +140,37 @@ describe("AddItemForm", () => {
 
     const nameInput = screen.getByPlaceholderText("Item name...");
     expect(nameInput).toBeRequired();
+  });
+
+  it("does not render the mic button when speech is not supported", () => {
+    mockVoiceSupported = false;
+    render(
+      <AddItemForm
+        listId="list-1"
+        categories={mockCategories}
+        addItemAction={mockAddItemAction}
+        createCategoryAction={mockCreateCategoryAction}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Voice input" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the mic button when speech is supported", () => {
+    mockVoiceSupported = true;
+    render(
+      <AddItemForm
+        listId="list-1"
+        categories={mockCategories}
+        addItemAction={mockAddItemAction}
+        createCategoryAction={mockCreateCategoryAction}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Voice input" })
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -18,6 +18,8 @@ import { useActionState, useRef, useState, useEffect } from "react";
 import { SubmitButton } from "@/components/SubmitButton";
 import { CreateCategoryForm } from "@/components/CreateCategoryForm";
 import { createClient } from "@/lib/supabase/client";
+import { useVoiceInput } from "@/hooks/useVoiceInput";
+import { parsePortugueseInput } from "@/lib/voice-parser";
 import type { ActionResult } from "@/app/(protected)/actions";
 import type { Category, Product } from "@/lib/types";
 
@@ -47,10 +49,30 @@ export function AddItemForm({
   const formRef = useRef<HTMLFormElement>(null);
   const [showNewCategory, setShowNewCategory] = useState(false);
 
-  // ─── Autocomplete state ───
+  // ─── Form field state ───
+  // Name, quantity, and unit are all controlled so voice input can fill them.
   const [nameValue, setNameValue] = useState("");
+  const [quantityValue, setQuantityValue] = useState("1");
+  const [unitValue, setUnitValue] = useState("");
+
+  // ─── Autocomplete state ───
   const [suggestions, setSuggestions] = useState<Product[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
+
+  // ─── Voice input ───
+  // Uses the Web Speech API to convert speech to text (Portuguese).
+  // The browser handles all the heavy lifting — no external service needed.
+  const { isSupported: voiceSupported, isListening, startListening, stopListening } =
+    useVoiceInput({
+      lang: "pt-PT",
+      onResult: (transcript) => {
+        // Parse "2 espinafres" into { quantity: 2, name: "espinafres" }
+        const parsed = parsePortugueseInput(transcript);
+        setNameValue(parsed.name);
+        setQuantityValue(String(parsed.quantity));
+        setUnitValue(parsed.unit ?? "");
+      },
+    });
 
   // Debounced search: query products after the user stops typing for 300ms.
   // Both branches run inside setTimeout so setState is never called
@@ -88,6 +110,8 @@ export function AddItemForm({
       if (!result.error) {
         formRef.current?.reset();
         setNameValue("");
+        setQuantityValue("1");
+        setUnitValue("");
         setSuggestions([]);
       }
       return result;
@@ -100,25 +124,62 @@ export function AddItemForm({
       <form ref={formRef} action={formAction} className="flex flex-col gap-3">
         <input type="hidden" name="list_id" value={listId} />
 
-        {/* Item name with autocomplete suggestions */}
+        {/* Item name with autocomplete suggestions and voice input */}
         <div className="relative">
-          <input
-            type="text"
-            name="name"
-            placeholder="Item name..."
-            required
-            value={nameValue}
-            onChange={(e) => setNameValue(e.target.value)}
-            onFocus={() => {
-              if (suggestions.length > 0) setShowSuggestions(true);
-            }}
-            onBlur={() => {
-              // Small delay so click on suggestion registers before hiding
-              setTimeout(() => setShowSuggestions(false), 150);
-            }}
-            autoComplete="off"
-            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none"
-          />
+          <div className="flex gap-2">
+            <input
+              type="text"
+              name="name"
+              placeholder="Item name..."
+              required
+              value={nameValue}
+              onChange={(e) => setNameValue(e.target.value)}
+              onFocus={() => {
+                if (suggestions.length > 0) setShowSuggestions(true);
+              }}
+              onBlur={() => {
+                // Small delay so click on suggestion registers before hiding
+                setTimeout(() => setShowSuggestions(false), 150);
+              }}
+              autoComplete="off"
+              className="flex-1 rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none"
+            />
+
+            {/* Microphone button — only shown if the browser supports speech recognition.
+                Tapping it starts listening; tapping again (or waiting) stops it. */}
+            {voiceSupported && (
+              <button
+                type="button"
+                onClick={isListening ? stopListening : startListening}
+                aria-label={isListening ? "Stop listening" : "Voice input"}
+                className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-md border transition-colors ${
+                  isListening
+                    ? "border-red-300 bg-red-50 text-red-500"
+                    : "border-zinc-300 text-zinc-400 hover:bg-zinc-50 hover:text-zinc-600"
+                }`}
+              >
+                {isListening ? (
+                  /* Pulsing red dot while listening */
+                  <span className="h-3 w-3 rounded-full bg-red-500 animate-pulse" />
+                ) : (
+                  /* Microphone icon */
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z"
+                    />
+                  </svg>
+                )}
+              </button>
+            )}
+          </div>
 
           {/* Suggestions dropdown */}
           {showSuggestions && suggestions.length > 0 && (
@@ -149,7 +210,8 @@ export function AddItemForm({
           <input
             type="number"
             name="quantity"
-            defaultValue={1}
+            value={quantityValue}
+            onChange={(e) => setQuantityValue(e.target.value)}
             min={0.01}
             step="any"
             className="w-20 rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none"
@@ -157,6 +219,8 @@ export function AddItemForm({
           <input
             type="text"
             name="unit"
+            value={unitValue}
+            onChange={(e) => setUnitValue(e.target.value)}
             placeholder="kg, L, pack..."
             className="w-28 rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none"
           />

--- a/src/hooks/useVoiceInput.ts
+++ b/src/hooks/useVoiceInput.ts
@@ -1,0 +1,128 @@
+/**
+ * Custom hook that wraps the Web Speech API for voice input.
+ *
+ * The Web Speech API lets the browser convert speech to text using the
+ * device's microphone. It's built into Chrome, Safari, and Edge — no
+ * extra libraries needed.
+ *
+ * This hook handles:
+ * - Checking if the browser supports speech recognition
+ * - Starting/stopping the microphone
+ * - Returning the transcript when speech is recognized
+ * - Cleaning up when the component unmounts
+ */
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+
+// TypeScript doesn't include built-in types for the Web Speech API.
+// We declare a minimal interface covering only what we use — this avoids
+// needing a third-party types package.
+interface SpeechRecognitionEvent {
+  results: { [index: number]: { [index: number]: { transcript: string } } };
+}
+
+interface SpeechRecognitionInstance {
+  lang: string;
+  interimResults: boolean;
+  maxAlternatives: number;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onend: (() => void) | null;
+  onerror: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+// Check browser support once at module load (never changes during a session).
+// Safe for SSR because the typeof guard runs before accessing window.
+const isSupported =
+  typeof window !== "undefined" &&
+  !!(window.SpeechRecognition || window.webkitSpeechRecognition);
+
+/**
+ * Returns speech-to-text controls.
+ *
+ * @param lang  - BCP 47 language code (e.g. "pt-PT" for Portuguese)
+ * @param onResult - called with the recognized text when speech ends
+ */
+export function useVoiceInput({
+  lang,
+  onResult,
+}: {
+  lang: string;
+  onResult: (transcript: string) => void;
+}) {
+  const [isListening, setIsListening] = useState(false);
+
+  // Keep a ref to the recognition instance so we can stop/abort it
+  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+
+  // Store onResult in a ref so the callback always uses the latest version
+  // without needing to recreate the recognition instance
+  const onResultRef = useRef(onResult);
+  onResultRef.current = onResult;
+
+  const startListening = useCallback(() => {
+    if (!isSupported) return;
+
+    // Create a new instance each time (avoids stale state issues)
+    const SpeechRecognitionAPI =
+      window.SpeechRecognition || window.webkitSpeechRecognition;
+    const recognition = new SpeechRecognitionAPI!();
+
+    recognition.lang = lang;
+    recognition.interimResults = false; // Only return the final result
+    recognition.maxAlternatives = 1; // We only need the best guess
+
+    recognition.onresult = (event) => {
+      // The API returns a list of results — we want the first (and only)
+      // result's first alternative transcript
+      const transcript = event.results[0][0].transcript;
+      onResultRef.current(transcript);
+      setIsListening(false);
+    };
+
+    // onend fires when recognition stops for any reason (success, silence,
+    // or error). We use it as a catch-all to reset the listening state.
+    recognition.onend = () => {
+      setIsListening(false);
+    };
+
+    recognition.onerror = () => {
+      // Common errors: "not-allowed" (mic permission denied),
+      // "no-speech" (user didn't say anything). In all cases we just
+      // stop listening — the user can tap the mic button again.
+      setIsListening(false);
+    };
+
+    recognitionRef.current = recognition;
+    recognition.start();
+    setIsListening(true);
+  }, [lang]);
+
+  const stopListening = useCallback(() => {
+    recognitionRef.current?.stop();
+    setIsListening(false);
+  }, []);
+
+  // Clean up: if the component unmounts while listening, abort recognition
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.abort();
+    };
+  }, []);
+
+  return { isSupported, isListening, startListening, stopListening };
+}

--- a/src/lib/voice-parser.test.ts
+++ b/src/lib/voice-parser.test.ts
@@ -1,0 +1,170 @@
+import { parsePortugueseInput } from "./voice-parser";
+
+describe("parsePortugueseInput", () => {
+  // --- Digit + name (singularized and capitalized) ---
+  it("parses a digit followed by a product name", () => {
+    expect(parsePortugueseInput("2 espinafres")).toEqual({
+      quantity: 2,
+      unit: null,
+      name: "Espinafre",
+    });
+  });
+
+  it("parses a decimal quantity with comma", () => {
+    expect(parsePortugueseInput("1,5 litros de leite")).toEqual({
+      quantity: 1.5,
+      unit: "L",
+      name: "Leite",
+    });
+  });
+
+  // --- Compound patterns ---
+  it("parses 'meio quilo de'", () => {
+    expect(parsePortugueseInput("meio quilo de arroz")).toEqual({
+      quantity: 0.5,
+      unit: "kg",
+      name: "Arroz",
+    });
+  });
+
+  it("parses 'um quilo de'", () => {
+    expect(parsePortugueseInput("um quilo de batatas")).toEqual({
+      quantity: 1,
+      unit: "kg",
+      name: "Batata",
+    });
+  });
+
+  it("parses 'meio litro de'", () => {
+    expect(parsePortugueseInput("meio litro de leite")).toEqual({
+      quantity: 0.5,
+      unit: "L",
+      name: "Leite",
+    });
+  });
+
+  it("parses 'uma dúzia de'", () => {
+    expect(parsePortugueseInput("uma dúzia de ovos")).toEqual({
+      quantity: 12,
+      unit: null,
+      name: "Ovo",
+    });
+  });
+
+  it("parses 'uma duzia de' (without accent)", () => {
+    expect(parsePortugueseInput("uma duzia de ovos")).toEqual({
+      quantity: 12,
+      unit: null,
+      name: "Ovo",
+    });
+  });
+
+  // --- Number word + unit ---
+  it("parses 'dois litros de'", () => {
+    expect(parsePortugueseInput("dois litros de sumo")).toEqual({
+      quantity: 2,
+      unit: "L",
+      name: "Sumo",
+    });
+  });
+
+  it("parses 'três pacotes de'", () => {
+    expect(parsePortugueseInput("3 pacotes de massa")).toEqual({
+      quantity: 3,
+      unit: "pack",
+      name: "Massa",
+    });
+  });
+
+  // --- Number word without unit ---
+  it("parses a Portuguese number word followed by a name", () => {
+    expect(parsePortugueseInput("cinco bananas")).toEqual({
+      quantity: 5,
+      unit: null,
+      name: "Banana",
+    });
+  });
+
+  // --- Name only (fallback) ---
+  it("defaults to quantity 1 when no number is given", () => {
+    expect(parsePortugueseInput("leite")).toEqual({
+      quantity: 1,
+      unit: null,
+      name: "Leite",
+    });
+  });
+
+  // --- Edge cases ---
+  it("handles extra whitespace", () => {
+    expect(parsePortugueseInput("  2   espinafres  ")).toEqual({
+      quantity: 2,
+      unit: null,
+      name: "Espinafre",
+    });
+  });
+
+  it("handles uppercase input", () => {
+    expect(parsePortugueseInput("LEITE")).toEqual({
+      quantity: 1,
+      unit: null,
+      name: "Leite",
+    });
+  });
+
+  it("returns empty name for empty input", () => {
+    expect(parsePortugueseInput("")).toEqual({
+      quantity: 1,
+      unit: null,
+      name: "",
+    });
+  });
+
+  it("handles 'meio' without a unit as quantity 0.5", () => {
+    expect(parsePortugueseInput("meio melão")).toEqual({
+      quantity: 0.5,
+      unit: null,
+      name: "Melão",
+    });
+  });
+
+  // --- Portuguese plural → singular patterns ---
+  it("converts -ões to -ão (limões → Limão)", () => {
+    expect(parsePortugueseInput("3 limões")).toEqual({
+      quantity: 3,
+      unit: null,
+      name: "Limão",
+    });
+  });
+
+  it("converts -ães to -ão (pães → Pão)", () => {
+    expect(parsePortugueseInput("2 pães")).toEqual({
+      quantity: 2,
+      unit: null,
+      name: "Pão",
+    });
+  });
+
+  it("converts -ns to -m (atuns → Atum)", () => {
+    expect(parsePortugueseInput("3 atuns")).toEqual({
+      quantity: 3,
+      unit: null,
+      name: "Atum",
+    });
+  });
+
+  it("converts -éis to -el (papéis → Papel)", () => {
+    expect(parsePortugueseInput("2 papéis")).toEqual({
+      quantity: 2,
+      unit: null,
+      name: "Papel",
+    });
+  });
+
+  it("leaves already-singular words unchanged", () => {
+    expect(parsePortugueseInput("arroz")).toEqual({
+      quantity: 1,
+      unit: null,
+      name: "Arroz",
+    });
+  });
+});

--- a/src/lib/voice-parser.ts
+++ b/src/lib/voice-parser.ts
@@ -1,0 +1,137 @@
+/**
+ * Parses Portuguese voice input into a structured item.
+ *
+ * The Web Speech API returns a plain string like "2 espinafres" or
+ * "meio quilo de arroz". This function extracts the quantity, unit,
+ * and product name so we can fill the Add Item form automatically.
+ */
+
+/** Maps Portuguese number words to their numeric values */
+const WORD_TO_NUMBER: Record<string, number> = {
+  meio: 0.5,
+  meia: 0.5,
+  um: 1,
+  uma: 1,
+  dois: 2,
+  duas: 2,
+  "três": 3,
+  tres: 3,
+  quatro: 4,
+  cinco: 5,
+  seis: 6,
+  sete: 7,
+  oito: 8,
+  nove: 9,
+  dez: 10,
+  onze: 11,
+  doze: 12,
+};
+
+/**
+ * Maps Portuguese unit words to the form field value.
+ * Each entry has a list of spoken variations and the value we store.
+ */
+const UNIT_MAP: Record<string, string> = {
+  quilo: "kg",
+  quilos: "kg",
+  kg: "kg",
+  litro: "L",
+  litros: "L",
+  pacote: "pack",
+  pacotes: "pack",
+};
+
+export interface ParsedVoiceInput {
+  name: string;
+  quantity: number;
+  unit: string | null;
+}
+
+/**
+ * Converts a Portuguese plural word to singular.
+ *
+ * Portuguese has several plural patterns. We handle the most common ones
+ * that appear in grocery products:
+ *
+ *   -ões → -ão  (limões → limão, melões → melão)
+ *   -ães → -ão  (pães → pão)
+ *   -ns  → -m   (atuns → atum)
+ *   -éis → -el  (papéis → papel)
+ *   -s   → drop (bananas → banana, espinafres → espinafre, ovos → ovo)
+ *
+ * Words that don't end in -s are returned unchanged (arroz, leite, etc.).
+ */
+function toSingular(word: string): string {
+  if (word.endsWith("ões")) return word.slice(0, -3) + "ão";
+  if (word.endsWith("ães")) return word.slice(0, -3) + "ão";
+  if (word.endsWith("ns")) return word.slice(0, -2) + "m";
+  if (word.endsWith("éis")) return word.slice(0, -3) + "el";
+  if (word.endsWith("s")) return word.slice(0, -1);
+  return word;
+}
+
+/** Capitalizes the first letter: "espinafre" → "Espinafre" */
+function capitalize(word: string): string {
+  if (!word) return word;
+  return word[0].toUpperCase() + word.slice(1);
+}
+
+/** Applies singular + capitalize to the product name */
+function formatName(name: string): string {
+  return capitalize(toSingular(name));
+}
+
+// Pre-build the general-purpose regex once (the maps never change).
+// Matches: (number or word) [optional: unit word + "de"] (product name)
+const numberWords = Object.keys(WORD_TO_NUMBER).join("|");
+const unitWords = Object.keys(UNIT_MAP).join("|");
+const GENERAL_PATTERN = new RegExp(
+  `^(\\d+(?:[.,]\\d+)?|${numberWords})\\s+` + // quantity
+    `(?:(${unitWords})\\s+de\\s+)?` + // optional: unit + "de"
+    `(.+)$` // product name
+);
+
+// "dúzia" needs a special pattern because it's not a unit (it's a quantity of 12)
+const DUZIA_PATTERN = /^uma\s+d[uú]zia\s+de\s+(.+)$/;
+
+/**
+ * Parses a Portuguese voice transcript into quantity, unit, and product name.
+ * The name is automatically singularized and capitalized.
+ *
+ * Examples:
+ *  - "2 espinafres"        → { quantity: 2, unit: null, name: "Espinafre" }
+ *  - "meio quilo de arroz" → { quantity: 0.5, unit: "kg", name: "Arroz" }
+ *  - "uma dúzia de ovos"   → { quantity: 12, unit: null, name: "Ovo" }
+ *  - "leite"               → { quantity: 1, unit: null, name: "Leite" }
+ */
+export function parsePortugueseInput(text: string): ParsedVoiceInput {
+  const normalized = text.toLowerCase().replace(/\s+/g, " ").trim();
+
+  if (!normalized) {
+    return { name: "", quantity: 1, unit: null };
+  }
+
+  // "uma dúzia de X" → 12 (special case — dúzia is a quantity, not a unit)
+  const duzia = normalized.match(DUZIA_PATTERN);
+  if (duzia) {
+    return { name: formatName(duzia[1]), quantity: 12, unit: null };
+  }
+
+  // General pattern handles most cases:
+  // "2 espinafres", "meio quilo de arroz", "dois litros de sumo", etc.
+  const general = normalized.match(GENERAL_PATTERN);
+
+  if (general) {
+    const [, rawQty, rawUnit, name] = general;
+
+    const quantity =
+      WORD_TO_NUMBER[rawQty] ?? parseFloat(rawQty.replace(",", "."));
+
+    const unit = rawUnit ? (UNIT_MAP[rawUnit] ?? null) : null;
+
+    return { name: formatName(name.trim()), quantity, unit };
+  }
+
+  // Fallback: entire text is the product name
+  return { name: formatName(normalized), quantity: 1, unit: null };
+}


### PR DESCRIPTION
## What
Add template lists with recurrence reminders, a custom confirm dialog, and voice input for adding items.

## Why
Phase 9 of the project: users need reusable templates (e.g., "Weekly Groceries") to avoid recreating the same shopping lists. Voice input improves the mobile shopping experience by letting users speak product names in Portuguese instead of typing.

## Jira related ticket
- N/A

## Changes

### Template lists
- Add `is_template` and `recurrence` fields to shopping lists schema
- Add templates page (`/templates`) with create, edit, delete, and "Use Template" flow
- Add `TemplateCard` component with inline recurrence editing (weekly/monthly/none)
- Add `TemplateReminderBanner` on the home page when a recurring template is due
- Add "Save as Template" button on regular list pages
- Add `EmptyTemplateState` component
- Add Phase 9 database migration (`phase9_template_lists.sql`)

### Custom confirm dialog
- Replace native `window.confirm` with a `ConfirmDialog` component + `useConfirm` hook
- Applied across all delete actions (lists, items, prices, products, stores, discounts)

### Voice input
- Add `useVoiceInput` hook wrapping the Web Speech API (pt-PT)
- Add `parsePortugueseInput` parser — extracts quantity, unit, and product name from spoken Portuguese (e.g., "2 espinafres" → qty: 2, name: "Espinafre")
- Handles Portuguese plurals → singular (limões → Limão, pães → Pão, atuns → Atum)
- Add mic button to `AddItemForm` (hidden on unsupported browsers)

### Other
- Add `MobileNav` bottom navigation bar
- Add loading state (`loading.tsx`) and 404 page (`not-found.tsx`)
- Add `ActionFormButton` reusable component for server action buttons with success feedback
- Add `constants.ts` with recurrence options
- Update E2E tests for new confirm dialog flow

## Testing
```sh
# Unit tests
npx jest voice-parser --no-coverage
npx jest AddItemForm --no-coverage

# Full test suite
npm test

# Build
npm run build
```

- Voice input: open a list on Chrome mobile, tap the mic button, say "2 espinafres" → fields fill with qty: 2, name: "Espinafre"
- Templates: create a list → "Save as Template" → go to /templates → "Use Template" creates a new list
- Reminders: set a template to "Weekly", verify the banner appears on the home page
- Confirm dialog: try deleting any item and verify the custom dialog appears

## Checklist
- `npm run validate` passes
- Coverage ≥ 80%
- Visual verification done