### PR TITLE
refactor: extract MicrophoneIcon into reusable component

### DIFF
--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -17,6 +17,7 @@
 import { useActionState, useRef, useState, useEffect } from "react";
 import { SubmitButton } from "@/components/SubmitButton";
 import { CreateCategoryForm } from "@/components/CreateCategoryForm";
+import { MicrophoneIcon } from "@/components/MicrophoneIcon";
 import { createClient } from "@/lib/supabase/client";
 import { useVoiceInput } from "@/hooks/useVoiceInput";
 import { parsePortugueseInput } from "@/lib/voice-parser";
@@ -162,20 +163,7 @@ export function AddItemForm({
                   /* Pulsing red dot while listening */
                   <span className="h-3 w-3 rounded-full bg-red-500 animate-pulse" />
                 ) : (
-                  /* Microphone icon */
-                  <svg
-                    className="h-5 w-5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z"
-                    />
-                  </svg>
+                  <MicrophoneIcon />
                 )}
               </button>
             )}

--- a/src/components/MicrophoneIcon.tsx
+++ b/src/components/MicrophoneIcon.tsx
@@ -1,0 +1,21 @@
+/**
+ * Microphone SVG icon used by voice input features
+ * (adding items and voice-guided shopping).
+ */
+export function MicrophoneIcon() {
+  return (
+    <svg
+      className="h-5 w-5"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## What
Extracts the inline microphone SVG from `AddItemForm` into a standalone `MicrophoneIcon` component.

## Why
The microphone icon was inlined as raw SVG inside `AddItemForm`. Extracting it into its own component makes it reusable across other voice features and keeps the form component cleaner.

## Jira related ticket
- N/A

## Changes
- Created `src/components/MicrophoneIcon.tsx` with the microphone SVG as a named export
- Updated `AddItemForm.tsx` to import and use `MicrophoneIcon` instead of the inline SVG

## Testing
- `npm run build` passes
- Voice input button in AddItemForm renders the microphone icon as before

## Checklist
- `npm run validate` passes
- Visual verification done