### PR TITLE
fix: prevent duplicate category creation

### DIFF
--- a/src/app/(protected)/actions.ts
+++ b/src/app/(protected)/actions.ts
@@ -547,6 +547,18 @@ export async function createCategory(
     return { error: "You must be logged in." };
   }
 
+  // Check if a default category with the same name already exists
+  const { data: existing } = await supabase
+    .from("categories")
+    .select("id")
+    .is("user_id", null)
+    .ilike("name", name.trim())
+    .maybeSingle();
+
+  if (existing) {
+    return { error: "A category with this name already exists." };
+  }
+
   const { error } = await supabase
     .from("categories")
     .insert({ name: name.trim(), user_id: user.id });


### PR DESCRIPTION
## What
Prevent users from creating custom categories that duplicate default category names.

## Why
Users could create a custom category (e.g., "Frutas") with the same name as a default category. The DB unique constraint `(name, user_id)` allowed this because `null` (default) and a real user_id are different values. This caused duplicate entries in the category dropdown.

## Jira related ticket
- N/A

## Changes
- Add a check in `createCategory` action to query for existing default categories (case-insensitive) before inserting a new one
- Return an error message if a default category with the same name already exists

## Testing
1. Open a shopping list and try to create a new category with the name "Frutas" (or any default category)
2. Should see the error: "A category with this name already exists."
3. Try creating a category with a unique name — should work as before

## Screenshot
N/A

## Checklist
- `npm run validate` passes
- Coverage ≥ 80%
- Visual verification done