### PR TITLE
fix: make unit matching case-insensitive and title-case product names

### DIFF
--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -53,12 +53,16 @@ export function AddItemForm({
   const formRef = useRef<HTMLFormElement>(null);
   const [showNewCategory, setShowNewCategory] = useState(false);
 
+  // Case-insensitive match to handle subtle data differences
+  // (e.g. trailing whitespace or casing in the DB)
+  const findUnitByAbbr = (abbr: string) =>
+    units.find((u) => u.abbreviation.trim().toLowerCase() === abbr.toLowerCase());
+
   // ─── Form field state ───
   // Name, quantity, and unit are all controlled so voice input can fill them.
   const [nameValue, setNameValue] = useState("");
   const [quantityValue, setQuantityValue] = useState("1");
-  // Default unit is "Un" (Unidade)
-  const defaultUnitId = units.find((u) => u.abbreviation === "Un")?.id ?? units[0]?.id ?? "";
+  const defaultUnitId = findUnitByAbbr("Un")?.id ?? units[0]?.id ?? "";
   const [unitValue, setUnitValue] = useState(defaultUnitId);
   const [categoryValue, setCategoryValue] = useState("");
 
@@ -79,7 +83,7 @@ export function AddItemForm({
         setQuantityValue(String(parsed.quantity));
         // Map the parsed abbreviation (e.g. "Kg") to the unit ID
         const matchedUnit = parsed.unit
-          ? units.find((u) => u.abbreviation === parsed.unit)
+          ? findUnitByAbbr(parsed.unit)
           : null;
         setUnitValue(matchedUnit?.id ?? defaultUnitId);
         // Match the spoken category name against available categories

--- a/src/lib/voice-parser.test.ts
+++ b/src/lib/voice-parser.test.ts
@@ -261,4 +261,33 @@ describe("parsePortugueseInput", () => {
       category: null,
     });
   });
+
+  // --- Unit "unidades" recognition with category ---
+  it("parses '7 unidades de laranjas na categoria frutas'", () => {
+    expect(parsePortugueseInput("7 unidades de laranjas na categoria frutas")).toEqual({
+      quantity: 7,
+      unit: "Un",
+      name: "Laranja",
+      category: "Frutas",
+    });
+  });
+
+  // --- Title case for multi-word product names ---
+  it("title-cases multi-word names, keeping small words lowercase", () => {
+    expect(parsePortugueseInput("2 sumo de laranja")).toEqual({
+      quantity: 2,
+      unit: null,
+      name: "Sumo de Laranja",
+      category: null,
+    });
+  });
+
+  it("title-cases 'gelado de baunilha'", () => {
+    expect(parsePortugueseInput("gelado de baunilha")).toEqual({
+      quantity: 1,
+      unit: null,
+      name: "Gelado de Baunilha",
+      category: null,
+    });
+  });
 });

--- a/src/lib/voice-parser.ts
+++ b/src/lib/voice-parser.ts
@@ -85,9 +85,27 @@ function capitalize(word: string): string {
   return word[0].toUpperCase() + word.slice(1);
 }
 
-/** Applies singular + capitalize to the product name */
+const SMALL_WORDS = new Set(["de", "e", "do", "da", "dos", "das", "em", "no", "na", "nos", "nas", "com", "por", "para", "ao", "aos"]);
+
+/**
+ * Title-cases a product name: capitalizes each word except Portuguese
+ * small words (de, e, do, da, etc.). The first word is always capitalized.
+ *
+ * Examples:
+ *   "sumo de laranja" → "Sumo de Laranja"
+ *   "leite e cereais" → "Leite e Cereais"
+ *   "pão"             → "Pão"
+ */
+function titleCase(text: string): string {
+  return text
+    .split(" ")
+    .map((word, i) => (i === 0 || !SMALL_WORDS.has(word)) ? capitalize(word) : word)
+    .join(" ");
+}
+
+/** Applies singular + title case to the product name */
 function formatName(name: string): string {
-  return capitalize(toSingular(name));
+  return titleCase(toSingular(name));
 }
 
 // Pre-build the general-purpose regex once (the maps never change).


### PR DESCRIPTION
## What
Fix the default unit dropdown showing "Emb" instead of "Un" and title-case multi-word product names from voice input.

## Why
The unit abbreviation matching used strict equality (`===`), which failed when the database value had subtle differences (casing or whitespace), causing the fallback to `units[0]` (Embalagem). Additionally, voice-parsed product names with multiple words (e.g., "sumo de laranja") only capitalized the first word.

## Jira related ticket
- N/A

## Changes
- **AddItemForm.tsx**: Extract `findUnitByAbbr` helper that does case-insensitive, whitespace-trimmed matching — used for both the default unit selection and voice unit matching
- **voice-parser.ts**: Add `titleCase` function that capitalizes each word except Portuguese small words (de, e, do, da, etc.), replacing the previous single-word `capitalize` approach
- **voice-parser.test.ts**: Add 3 test cases covering "7 unidades de laranjas na categoria frutas" parsing, and multi-word title casing

## Testing
```bash
npx jest voice-parser    # Voice parser tests (31 passing)
npx jest AddItemForm     # Form tests (7 passing)
npx jest                 # Full suite (188 passing)
```

## Checklist
- [x] All 188 tests pass
- [x] No regressions in existing test cases