### PR TITLE
fix: remove HTML form reset that overrides unit dropdown state

### DIFF
--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -131,7 +131,6 @@ export function AddItemForm({
     async (previousState: ActionResult, formData: FormData) => {
       const result = await addItemAction(previousState, formData);
       if (!result.error) {
-        formRef.current?.reset();
         setNameValue("");
         setQuantityValue("1");
         setUnitValue(defaultUnitId);


### PR DESCRIPTION
## What
Remove `formRef.current?.reset()` from the AddItemForm success handler so the unit dropdown correctly resets to "Un" after adding a product.

## Why
`formRef.current?.reset()` resets the DOM select to its first alphabetical option ("Emb") before React's transition (from `useActionState`) can re-render with the correct "Un" state. Since all form fields are already reset individually via `setState` calls, the HTML form reset is redundant and causes the unit dropdown to flash/stick on "Emb".

## Jira related ticket
- N/A

## Changes
- **AddItemForm.tsx**: Remove `formRef.current?.reset()` from the `useActionState` success handler (line 134). All controlled fields are already reset via `setNameValue("")`, `setQuantityValue("1")`, `setUnitValue(defaultUnitId)`, `setCategoryValue("")`, and `setSuggestions([])`.

## Testing
```bash
npx jest AddItemForm    # Form tests (7 passing)
npx jest                # Full suite (188 passing)
```

## Checklist
- [x] All 188 tests pass
- [x] No regressions