### PR TITLE
fix: always run category bootstrap and backfill existing users

### DIFF
--- a/e2e/categories.spec.ts
+++ b/e2e/categories.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * Categories E2E tests.
+ *
+ * Regression test for the "missing default categories" bug: every
+ * user should see the 11 default categories on /categories after
+ * the protected layout bootstraps them into their account.
+ *
+ * The protected layout calls bootstrap_user_categories() on every
+ * page load (idempotent), so any logged-in user — including the
+ * test user from auth.setup.ts — has their defaults by the time
+ * this page renders.
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe("Categories page", () => {
+  test("shows default categories after bootstrap", async ({ page }) => {
+    await page.goto("/categories");
+
+    // Spot-check a few defaults from supabase/seed.sql.
+    // We check several rather than all 11 to keep the test concise —
+    // if bootstrap ran, they all got copied together.
+    await expect(page.getByText("Bebidas", { exact: true })).toBeVisible();
+    await expect(page.getByText("Frutas", { exact: true })).toBeVisible();
+    await expect(page.getByText("Cereais", { exact: true })).toBeVisible();
+    await expect(page.getByText("Limpeza", { exact: true })).toBeVisible();
+  });
+});

--- a/src/app/(protected)/categories/page.tsx
+++ b/src/app/(protected)/categories/page.tsx
@@ -11,9 +11,10 @@ export const metadata: Metadata = { title: "My Categories" };
  * Categories page — shows the user's categories.
  *
  * All categories are user-owned. Default categories (like "Bebidas",
- * "Frutas", etc.) are copied into each user's account on first login
- * by the bootstrap_user_categories() database function, so every user
- * can freely rename or delete them.
+ * "Frutas", etc.) are copied into each user's account by the
+ * bootstrap_user_categories() database function — the protected
+ * layout calls it on every page load (it's idempotent), so every
+ * user always has their defaults and can freely rename or delete them.
  *
  * The page follows the same layout pattern as the Stores page:
  * a creation form at the top, then the list of existing categories.

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -34,20 +34,16 @@ export default async function ProtectedLayout({
     redirect("/login");
   }
 
-  // Bootstrap default categories into the user's account on first visit.
-  // This copies the shared default categories (user_id = null) so the
-  // user owns them and can edit/delete freely. The function is idempotent,
-  // but we skip the call entirely if the user already has categories.
-  const { count } = await supabase
-    .from("categories")
-    .select("*", { count: "exact", head: true })
-    .eq("user_id", user.id);
-
-  if (count === 0) {
-    await supabase.rpc("bootstrap_user_categories", {
-      target_user_id: user.id,
-    });
-  }
+  // Bootstrap default categories into the user's account.
+  // The RPC copies the shared defaults (user_id = null) so the user
+  // owns them and can edit/delete freely. It's idempotent (uses
+  // ON CONFLICT DO NOTHING), so we call it on every protected page
+  // load — a handful of conflict-skipped inserts is cheaper than a
+  // fragile "have they been bootstrapped yet?" gate, and it ensures
+  // every user always has their defaults.
+  await supabase.rpc("bootstrap_user_categories", {
+    target_user_id: user.id,
+  });
 
   return (
     <div className="min-h-screen bg-zinc-50">

--- a/supabase/migrations/20260423120000_backfill_user_category_bootstrap.sql
+++ b/supabase/migrations/20260423120000_backfill_user_category_bootstrap.sql
@@ -1,0 +1,23 @@
+-- ============================================================
+-- Backfill: bootstrap default categories for existing users
+--
+-- Context: when bootstrap_user_categories() was introduced
+-- (migration 20260408120000), the protected layout only called
+-- it when the user had zero categories. Users who had already
+-- created their own categories were skipped, so their default
+-- categories were never copied into their account.
+--
+-- This migration runs the bootstrap once for every existing
+-- user to fix those accounts. It's safe to include in a fresh
+-- db reset too — the function uses ON CONFLICT DO NOTHING, so
+-- re-runs are idempotent.
+-- ============================================================
+
+do $$
+declare
+  u record;
+begin
+  for u in select id from auth.users loop
+    perform bootstrap_user_categories(u.id);
+  end loop;
+end $$;


### PR DESCRIPTION
The protected layout gated bootstrap_user_categories() on count === 0,
so users who had created their own categories before bootstrap landed
never got the defaults copied. Once list-data.ts stopped falling back
to user_id IS NULL, the missing defaults became visible in the UI.

- Always call the idempotent RPC on every protected page load.
- Add a migration that runs bootstrap for every existing auth.users row.
- Add an E2E regression check for default categories on /categories.
- Tighten the comment on the categories page.