### PR TITLE
feat: add item search with voice input to lists

### DIFF
--- a/src/app/(protected)/lists/[id]/page.tsx
+++ b/src/app/(protected)/lists/[id]/page.tsx
@@ -3,8 +3,7 @@ import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { fetchListPageData } from "@/lib/list-data";
 import { AddItemForm } from "@/components/AddItemForm";
-import { ListItemCard } from "@/components/ListItemCard";
-import { ItemPricesSection } from "@/components/ItemPricesSection";
+import { ListItemsSection } from "@/components/ListItemsSection";
 import { EmptyItemState } from "@/components/EmptyItemState";
 import { ShareListSection } from "@/components/ShareListSection";
 import { SubmitButton } from "@/components/SubmitButton";
@@ -28,7 +27,6 @@ import {
   createListFromTemplate,
   saveCategorySortOrder,
 } from "@/app/(protected)/actions";
-import { groupItemsByCategory } from "@/lib/list-helpers";
 
 /**
  * List detail page — shows a shopping list's items with the ability
@@ -92,8 +90,9 @@ export default async function ListDetailPage({
     userLists = (listsData ?? []) as typeof userLists;
   }
 
-  // Group items by category name so we can render them in sections
-  const sortedGroups = groupItemsByCategory(items, categorySortByName);
+  // Convert the prices Map into a plain object so it can be passed to a
+  // Client Component (Maps aren't serializable across the server/client boundary).
+  const pricesByProductObj = Object.fromEntries(pricesByProduct);
 
   // Build the list of categories actually used in this list (for the reorder UI).
   // We need both the category ID and name so the editor can save by ID.
@@ -231,54 +230,32 @@ export default async function ListDetailPage({
         </div>
       )}
 
-      {/* List items grouped by category, or empty state */}
+      {/* List items grouped by category, or empty state.
+          The interactive list (with the search box and voice button) lives
+          inside ListItemsSection — a Client Component — because it needs
+          local state to filter as the user types. */}
       <div className="mt-6">
         {items.length === 0 ? (
           <EmptyItemState />
         ) : (
-          <div className="flex flex-col gap-6">
-            {sortedGroups.map(([categoryName, groupItems]) => (
-              <div key={categoryName}>
-                {/* Category heading */}
-                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-400">
-                  {categoryName}
-                </p>
-                <div className="flex flex-col gap-2">
-                  {groupItems.map((item) => (
-                    <div
-                      key={item.id}
-                      className="rounded-md border border-zinc-200 bg-white"
-                    >
-                      {/* Item details (name, quantity, category, edit/delete) */}
-                      <ListItemCard
-                        item={item}
-                        categories={categories}
-                        units={units}
-                        updateAction={updateItem}
-                        deleteAction={deleteItem}
-                      />
-                      {/* Prices section — only shown if item has a product link */}
-                      {item.product_id && (
-                        <ItemPricesSection
-                          productId={item.product_id}
-                          listId={id}
-                          prices={pricesByProduct.get(item.product_id) ?? []}
-                          stores={stores}
-                          discounts={allDiscounts}
-                          addPriceAction={addPrice}
-                          updatePriceAction={updatePrice}
-                          deletePriceAction={deletePrice}
-                          addDiscountAction={addDiscount}
-                          updateDiscountAction={updateDiscount}
-                          deleteDiscountAction={deleteDiscount}
-                        />
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
+          <ListItemsSection
+            listId={id}
+            items={items}
+            categories={categories}
+            units={units}
+            stores={stores}
+            pricesByProduct={pricesByProductObj}
+            allDiscounts={allDiscounts}
+            categorySortByName={categorySortByName}
+            updateItemAction={updateItem}
+            deleteItemAction={deleteItem}
+            addPriceAction={addPrice}
+            updatePriceAction={updatePrice}
+            deletePriceAction={deletePrice}
+            addDiscountAction={addDiscount}
+            updateDiscountAction={updateDiscount}
+            deleteDiscountAction={deleteDiscount}
+          />
         )}
       </div>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,8 +26,12 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // suppressHydrationWarning silences false-positive hydration warnings
+  // caused by browser extensions (e.g. LanguageTool, Grammarly) that
+  // inject attributes like data-lt-installed onto <html> after the page
+  // loads. It only suppresses warnings on this element, not its children.
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -18,7 +18,7 @@ import { useActionState, useRef, useState, useEffect } from "react";
 import { SubmitButton } from "@/components/SubmitButton";
 import { CreateCategoryForm } from "@/components/CreateCategoryForm";
 import { AddToListsDialog } from "@/components/AddToListsDialog";
-import { MicrophoneIcon } from "@/components/MicrophoneIcon";
+import { VoiceButton } from "@/components/VoiceButton";
 import { createClient } from "@/lib/supabase/client";
 import { useVoiceInput } from "@/hooks/useVoiceInput";
 import { parsePortugueseInput } from "@/lib/voice-parser";
@@ -194,26 +194,13 @@ export function AddItemForm({
               className="flex-1 rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none"
             />
 
-            {/* Microphone button — only shown if the browser supports speech recognition.
-                Tapping it starts listening; tapping again (or waiting) stops it. */}
+            {/* Microphone — only on browsers that support speech recognition. */}
             {voiceSupported && (
-              <button
-                type="button"
-                onClick={isListening ? stopListening : startListening}
-                aria-label={isListening ? "Stop listening" : "Voice input"}
-                className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-md border transition-colors ${
-                  isListening
-                    ? "border-red-300 bg-red-50 text-red-500"
-                    : "border-zinc-300 text-zinc-400 hover:bg-zinc-50 hover:text-zinc-600"
-                }`}
-              >
-                {isListening ? (
-                  /* Pulsing red dot while listening */
-                  <span className="h-3 w-3 rounded-full bg-red-500 animate-pulse" />
-                ) : (
-                  <MicrophoneIcon />
-                )}
-              </button>
+              <VoiceButton
+                isListening={isListening}
+                onStart={startListening}
+                onStop={stopListening}
+              />
             )}
           </div>
 

--- a/src/components/ListItemsSection.tsx
+++ b/src/components/ListItemsSection.tsx
@@ -1,0 +1,130 @@
+/**
+ * Client wrapper around the grouped item cards on the list detail page.
+ *
+ * This is a Client Component so we can hold the search query in state and
+ * filter items by name as the user types or speaks. Server Actions for
+ * editing items, prices, and discounts are still defined in the server
+ * actions module — they're just passed in as props (Next.js serializes
+ * server action references across the server/client boundary).
+ */
+"use client";
+
+import { useState } from "react";
+import { ListItemCard } from "@/components/ListItemCard";
+import { ItemPricesSection } from "@/components/ItemPricesSection";
+import { SearchInput } from "@/components/SearchInput";
+import { filterItemsByName, groupItemsByCategory } from "@/lib/list-helpers";
+import type {
+  ListItemWithCategory,
+  Category,
+  Unit,
+  Store,
+  ItemPriceWithStore,
+  Discount,
+} from "@/lib/types";
+import type { ActionResult } from "@/app/(protected)/actions";
+
+type ServerAction = (
+  previousState: ActionResult,
+  formData: FormData
+) => Promise<ActionResult>;
+
+export function ListItemsSection({
+  listId,
+  items,
+  categories,
+  units,
+  stores,
+  pricesByProduct,
+  allDiscounts,
+  categorySortByName,
+  updateItemAction,
+  deleteItemAction,
+  addPriceAction,
+  updatePriceAction,
+  deletePriceAction,
+  addDiscountAction,
+  updateDiscountAction,
+  deleteDiscountAction,
+}: {
+  listId: string;
+  items: ListItemWithCategory[];
+  categories: Category[];
+  units: Unit[];
+  stores: Store[];
+  /** Prices keyed by product_id. A plain object (not a Map) because
+   *  Maps don't serialize from Server to Client Components. */
+  pricesByProduct: Record<string, ItemPriceWithStore[]>;
+  allDiscounts: Discount[];
+  categorySortByName?: Record<string, number>;
+  updateItemAction: ServerAction;
+  deleteItemAction: ServerAction;
+  addPriceAction: ServerAction;
+  updatePriceAction: ServerAction;
+  deletePriceAction: ServerAction;
+  addDiscountAction: ServerAction;
+  updateDiscountAction: ServerAction;
+  deleteDiscountAction: ServerAction;
+}) {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const filteredItems = filterItemsByName(items, searchQuery);
+  const sortedGroups = groupItemsByCategory(filteredItems, categorySortByName);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SearchInput
+        value={searchQuery}
+        onChange={setSearchQuery}
+        placeholder="Search items..."
+      />
+
+      {sortedGroups.length === 0 ? (
+        <p className="text-center text-sm text-zinc-500">
+          No items match &ldquo;{searchQuery}&rdquo;.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-6">
+          {sortedGroups.map(([categoryName, groupItems]) => (
+            <div key={categoryName}>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-400">
+                {categoryName}
+              </p>
+              <div className="flex flex-col gap-2">
+                {groupItems.map((item) => (
+                  <div
+                    key={item.id}
+                    className="rounded-md border border-zinc-200 bg-white"
+                  >
+                    <ListItemCard
+                      item={item}
+                      categories={categories}
+                      units={units}
+                      updateAction={updateItemAction}
+                      deleteAction={deleteItemAction}
+                    />
+                    {item.product_id && (
+                      <ItemPricesSection
+                        productId={item.product_id}
+                        listId={listId}
+                        prices={pricesByProduct[item.product_id] ?? []}
+                        stores={stores}
+                        discounts={allDiscounts}
+                        addPriceAction={addPriceAction}
+                        updatePriceAction={updatePriceAction}
+                        deletePriceAction={deletePriceAction}
+                        addDiscountAction={addDiscountAction}
+                        updateDiscountAction={updateDiscountAction}
+                        deleteDiscountAction={deleteDiscountAction}
+                      />
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,0 +1,61 @@
+/**
+ * Reusable search input with an optional voice button.
+ *
+ * Used in two places: the list detail page and shopping mode. The voice
+ * button only appears on browsers that support the Web Speech API; the
+ * spoken transcript goes straight into the box (no Portuguese parsing —
+ * users speak product names freely).
+ */
+"use client";
+
+import { VoiceButton } from "@/components/VoiceButton";
+import { useVoiceInput } from "@/hooks/useVoiceInput";
+
+export function SearchInput({
+  value,
+  onChange,
+  placeholder = "Search items...",
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+}) {
+  const { isSupported, isListening, startListening, stopListening } =
+    useVoiceInput({
+      lang: "pt-PT",
+      onResult: (transcript) => onChange(transcript),
+    });
+
+  return (
+    <div className="flex gap-2">
+      <div className="relative flex-1">
+        <input
+          type="search"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="w-full rounded-md border border-zinc-300 px-3 py-2 pr-8 text-sm focus:border-zinc-500 focus:outline-none"
+        />
+        {value && (
+          <button
+            type="button"
+            onClick={() => onChange("")}
+            aria-label="Clear search"
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600"
+          >
+            &times;
+          </button>
+        )}
+      </div>
+
+      {isSupported && (
+        <VoiceButton
+          isListening={isListening}
+          onStart={startListening}
+          onStop={stopListening}
+          idleLabel="Voice search"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/ShoppingList.tsx
+++ b/src/components/ShoppingList.tsx
@@ -20,8 +20,9 @@ import { useRouter } from "next/navigation";
 import { ShoppingProgressBar } from "@/components/ShoppingProgressBar";
 import { ShoppingItemCard } from "@/components/ShoppingItemCard";
 import { LiveShoppingMode } from "@/components/LiveShoppingMode";
+import { SearchInput } from "@/components/SearchInput";
 import { useConfirm } from "@/components/ConfirmDialog";
-import { groupItemsByCategory } from "@/lib/list-helpers";
+import { filterItemsByName, groupItemsByCategory } from "@/lib/list-helpers";
 import type { BestDealInfo } from "@/lib/types";
 import type { ListItemWithCategory } from "@/lib/types";
 import type { ActionResult } from "@/app/(protected)/actions";
@@ -63,6 +64,7 @@ export function ShoppingList({
   const router = useRouter();
   const [showPrices, setShowPrices] = useState(true);
   const [liveMode, setLiveMode] = useState(initialLiveMode);
+  const [searchQuery, setSearchQuery] = useState("");
   const [, startTransition] = useTransition();
   const deleteFormRef = useRef<HTMLFormElement>(null);
   const { requestConfirm, confirmDialog } = useConfirm();
@@ -128,13 +130,21 @@ export function ShoppingList({
     });
   }
 
-  // Split items into unchecked (remaining) and checked (done).
+  // Overall counts feed the progress bar — they ignore the search filter
+  // so progress doesn't appear to jump while the user types.
+  const totalCount = optimisticItems.length;
+  const checkedCount = optimisticItems.reduce(
+    (n, item) => n + (item.checked ? 1 : 0),
+    0
+  );
+
+  const filteredItems = filterItemsByName(optimisticItems, searchQuery);
+
   // Done items are sorted by checked_at descending so the most recently
-  // checked item shows at the top — matches what the user just put in
-  // the basket. Items without a timestamp (older data before this
-  // column existed) fall to the bottom.
-  const remainingItems = optimisticItems.filter((item) => !item.checked);
-  const doneItems = optimisticItems
+  // checked item shows at the top. Items without a timestamp (older data
+  // before this column existed) fall to the bottom.
+  const remainingItems = filteredItems.filter((item) => !item.checked);
+  const doneItems = filteredItems
     .filter((item) => item.checked)
     .sort((a, b) => {
       if (!a.checked_at && !b.checked_at) return 0;
@@ -162,14 +172,22 @@ export function ShoppingList({
 
   return (
     <div className="flex flex-col gap-4">
-      {/* Progress bar */}
+      {/* Progress bar — always reflects overall progress, ignoring the search filter */}
       <ShoppingProgressBar
-        checkedCount={doneItems.length}
-        totalCount={optimisticItems.length}
+        checkedCount={checkedCount}
+        totalCount={totalCount}
       />
 
-      {/* Start Live Shopping button — only when there are unchecked items */}
-      {remainingItems.length > 0 && (
+      {totalCount > 0 && (
+        <SearchInput
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder="Search items..."
+        />
+      )}
+
+      {/* Start Live Shopping — based on unchecked items overall, ignoring the search filter */}
+      {checkedCount < totalCount && (
         <button
           type="button"
           onClick={() => setLiveMode(true)}
@@ -177,6 +195,12 @@ export function ShoppingList({
         >
           Start Live Shopping
         </button>
+      )}
+
+      {searchQuery.trim() && remainingItems.length === 0 && doneItems.length === 0 && (
+        <p className="text-center text-sm text-zinc-500">
+          No items match &ldquo;{searchQuery}&rdquo;.
+        </p>
       )}
 
       {/* Price toggle — only shown if there are prices to display */}

--- a/src/components/VoiceButton.tsx
+++ b/src/components/VoiceButton.tsx
@@ -1,0 +1,42 @@
+/**
+ * Microphone button used by any input that supports voice entry.
+ *
+ * Centralises the styling and the listening/idle visual states so search
+ * and item-entry forms stay visually consistent.
+ */
+"use client";
+
+import { MicrophoneIcon } from "@/components/MicrophoneIcon";
+
+export function VoiceButton({
+  isListening,
+  onStart,
+  onStop,
+  idleLabel = "Voice input",
+  listeningLabel = "Stop listening",
+}: {
+  isListening: boolean;
+  onStart: () => void;
+  onStop: () => void;
+  idleLabel?: string;
+  listeningLabel?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={isListening ? onStop : onStart}
+      aria-label={isListening ? listeningLabel : idleLabel}
+      className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-md border transition-colors ${
+        isListening
+          ? "border-red-300 bg-red-50 text-red-500"
+          : "border-zinc-300 text-zinc-400 hover:bg-zinc-50 hover:text-zinc-600"
+      }`}
+    >
+      {isListening ? (
+        <span className="h-3 w-3 rounded-full bg-red-500 animate-pulse" />
+      ) : (
+        <MicrophoneIcon />
+      )}
+    </button>
+  );
+}

--- a/src/hooks/useVoiceInput.ts
+++ b/src/hooks/useVoiceInput.ts
@@ -22,13 +22,18 @@ interface SpeechRecognitionEvent {
   results: { [index: number]: { [index: number]: { transcript: string } } };
 }
 
+interface SpeechRecognitionErrorEvent {
+  error: string;
+  message?: string;
+}
+
 interface SpeechRecognitionInstance {
   lang: string;
   interimResults: boolean;
   maxAlternatives: number;
   onresult: ((event: SpeechRecognitionEvent) => void) | null;
   onend: (() => void) | null;
-  onerror: (() => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
   start: () => void;
   stop: () => void;
   abort: () => void;
@@ -100,16 +105,30 @@ export function useVoiceInput({
       setIsListening(false);
     };
 
-    recognition.onerror = () => {
-      // Common errors: "not-allowed" (mic permission denied),
-      // "no-speech" (user didn't say anything). In all cases we just
-      // stop listening — the user can tap the mic button again.
+    recognition.onerror = (event) => {
+      // Common errors: "not-allowed" (mic permission denied or insecure
+      // origin), "no-speech" (silence), "audio-capture" (no microphone),
+      // "network" (browser can't reach the speech service). We log it so
+      // the cause is visible in DevTools, then stop listening — the user
+      // can tap the mic button again.
+      console.warn(
+        `[useVoiceInput] speech recognition error: ${event.error}${
+          event.message ? ` — ${event.message}` : ""
+        }`
+      );
       setIsListening(false);
     };
 
     recognitionRef.current = recognition;
-    recognition.start();
-    setIsListening(true);
+    // start() can throw synchronously (InvalidStateError) if a previous
+    // recognition is still active. Guard so the UI doesn't get stuck.
+    try {
+      recognition.start();
+      setIsListening(true);
+    } catch (err) {
+      console.warn("[useVoiceInput] failed to start recognition:", err);
+      setIsListening(false);
+    }
   }, [lang]);
 
   const stopListening = useCallback(() => {

--- a/src/lib/list-helpers.ts
+++ b/src/lib/list-helpers.ts
@@ -67,6 +67,20 @@ export function groupItemsByCategory(
 }
 
 /**
+ * Filter items by a free-text search query (case-insensitive substring
+ * match against the item name). An empty/whitespace-only query returns
+ * the original array unchanged so callers don't need to special-case it.
+ */
+export function filterItemsByName<T extends { name: string }>(
+  items: T[],
+  query: string
+): T[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return items;
+  return items.filter((item) => item.name.toLowerCase().includes(normalized));
+}
+
+/**
  * Portuguese pluralization for unit names.
  *
  * Common patterns:


### PR DESCRIPTION
## What
Adds a search box (with optional voice input via the Web Speech API) to the list detail page and to shopping mode, so items can be filtered by name as the user types or speaks.

## Why
On a long shopping list it's hard to scroll-find a specific item — especially mid-shop on a phone in a noisy store. Search keeps the existing category grouping and prices intact while letting the user jump to one item; the mic button means it can be used hands-free.

## Jira related ticket
- No ticket — feature request from internal use.

## Changes
- New `SearchInput` component (text input + clear button + optional mic).
- New `VoiceButton` component, extracted from `AddItemForm` so the mic styling stays consistent across forms.
- New `ListItemsSection` Client Component wrapping the grouped item cards on the list detail page; the previous server-rendered grid moved here so the search filter can run client-side.
- New `filterItemsByName` helper in `list-helpers` so both call sites share the same case-insensitive substring filter.
- `ShoppingList` now shows the search box; the progress bar and "Start Live Shopping" button intentionally use overall counts so they don't bounce while typing.
- `useVoiceInput`: surfaces the underlying \`SpeechRecognitionErrorEvent\` via \`console.warn\` (e.g. \`not-allowed\`, \`audio-capture\`, \`network\`) and guards \`recognition.start()\` against synchronous throws.
- \`app/layout.tsx\`: \`suppressHydrationWarning\` on \`<html>\` to silence false-positive hydration warnings caused by browser extensions (LanguageTool, Grammarly) that inject attributes after load.

## Testing
1. \`npm run dev\` → open a list with several items.
2. Type in the search box → items filter by name across all categories; clearing the box restores the full grouping.
3. Click the mic (Chrome / Safari / Edge) → speak an item name → transcript fills the search box.
4. Repeat in **Start Shopping** mode (\`/lists/[id]/shop\`):
   - Search filters both Remaining and Done sections.
   - Progress bar still shows overall counts, not the filtered subset.
   - "Start Live Shopping" stays available while a search is active.
5. Existing voice on **Add item** still works (it now uses the shared \`VoiceButton\`).
6. \`npm test\` — unit tests pass (\`AddItemForm\`, \`voice-parser\`, etc).

## Screenshot
N/A — UI addition; verified locally in Chrome.

## Checklist
- [x] \`npm run validate\` (typecheck + tests) passes locally for changed files
- [x] Visual verification done in Chrome (search + voice both confirmed working by user)
- [ ] Coverage ≥ 80% — no new tests added for the search filter; happy to add if reviewer wants