### PR TITLE
chore: document Data API grants for new tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,13 @@ Tables to create (ask before implementing if unsure):
 - After creating a migration file, apply it locally with `supabase migration up` (or `supabase db reset` to wipe and re-apply everything from scratch).
 - Also update `supabase/schema.sql` to reflect the new shape — it's the human-readable reference, not the source of truth.
 - The hosted DB picks up new migrations on the next `supabase db push` / deploy.
+- **New tables must include explicit Data API grants.** Supabase is removing the auto-grant on `public` tables for all projects on 2026-10-30 — without an explicit `GRANT`, `supabase-js` / PostgREST returns a `42501` error. For every new `create table public.foo (...)`, add:
+  ```sql
+  grant select, insert, update, delete on public.foo to authenticated;
+  grant select, insert, update, delete on public.foo to service_role;
+  -- only add `grant select on public.foo to anon;` if the table must be readable when logged out
+  ```
+  RLS policies are still required on top — grants control role visibility, policies control per-row access.
 
 ## Code Style
 - Use TypeScript (but keep types simple — no complex generics)


### PR DESCRIPTION
## What
Document the new requirement that `create table public.<foo>` migrations include explicit Data API `GRANT`s.

## Why
Supabase emailed announcing that the auto-grant on `public` schema tables is being removed for all projects on **2026-10-30**. Existing tables retain their grants, but any new table created without explicit grants will be invisible to `supabase-js` / PostgREST (error `42501`). Capturing the convention in `CLAUDE.md` so future migrations don't get caught out.

## Jira related ticket
- No ticket.

## Changes
- `CLAUDE.md` — added a Database Migrations bullet describing the required `grant` statements for `authenticated` and `service_role` (and when to add `anon`), with a note that RLS policies remain required on top of the grants.

## Testing
Docs-only change — no code paths affected. The new convention will be exercised the next time we add a table migration; if a grant is missed, PostgREST returns `42501` with the exact `GRANT` to apply.

## Screenshot
N/A — documentation change.

## Checklist
- [ ] `npm run validate` passes (N/A — docs only)
- [ ] Coverage ≥ 80% (N/A — docs only)
- [ ] Visual verification done (N/A — docs only)